### PR TITLE
feat(aliases): use citext column for alias addresses

### DIFF
--- a/priv/repo/migrations/20230311124846_make_aliases_case_insensitive.exs
+++ b/priv/repo/migrations/20230311124846_make_aliases_case_insensitive.exs
@@ -1,0 +1,9 @@
+defmodule Shroud.Repo.Migrations.MakeAliasesCaseInsensitive do
+  use Ecto.Migration
+
+  def change do
+    alter table(:email_aliases) do
+      modify :address, :citext
+    end
+  end
+end


### PR DESCRIPTION
BREAKING CHANGE: admins must manually run the `make_emails_case_insensitive` command before deploying this.

run this command using:
```
docker compose exec web /home/elixir/app/bin/shroud rpc Shroud.Release.make_emails_case_insensitive
```