### PR TITLE
feat(api): API Endpoint to delete Alias

### DIFF
--- a/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
+++ b/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
@@ -76,6 +76,7 @@ defmodule ShroudWeb.Api.V1.EmailAliasController do
       |> render("error.json", error: "Alias not found")
     else
       Aliases.delete_email_alias(alias.id)
+
       conn
       |> send_resp(:no_content, "")
     end

--- a/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
+++ b/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
@@ -66,6 +66,7 @@ defmodule ShroudWeb.Api.V1.EmailAliasController do
     alias =
       EmailAlias
       |> where([ea], is_nil(ea.deleted_at))
+      |> where([ea], ea.user_id == ^conn.assigns.current_user.id)
       |> Repo.get_by(address: address)
 
     if is_nil(alias) do

--- a/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
+++ b/lib/shroud_web/controllers/api/v1/email_alias_controller.ex
@@ -61,4 +61,22 @@ defmodule ShroudWeb.Api.V1.EmailAliasController do
         |> render("error.json", error: "Unable to create email alias")
     end
   end
+
+  def delete(conn, %{"address" => address}) do
+    alias =
+      EmailAlias
+      |> where([ea], is_nil(ea.deleted_at))
+      |> Repo.get_by(address: address)
+
+    if is_nil(alias) do
+      conn
+      |> put_status(422)
+      |> put_view(ShroudWeb.ErrorView)
+      |> render("error.json", error: "Alias not found")
+    else
+      Aliases.delete_email_alias(alias.id)
+      conn
+      |> send_resp(:no_content, "")
+    end
+  end
 end

--- a/lib/shroud_web/router.ex
+++ b/lib/shroud_web/router.ex
@@ -50,6 +50,7 @@ defmodule ShroudWeb.Router do
     pipe_through([:api, :require_confirmed_api_user])
 
     resources("/aliases", EmailAliasController, only: [:index, :create])
+    delete("/aliases/:address", EmailAliasController, :delete)
     resources("/domains", DomainController, only: [:index])
   end
 


### PR DESCRIPTION
we use `DELETE [URL]/api/v1/aliases/:address` to delete alias.

close #68