### PR TITLE
fix: add dark mode support to email report page

### DIFF
--- a/lib/shroud_web/controllers/page_html/email_report.html.heex
+++ b/lib/shroud_web/controllers/page_html/email_report.html.heex
@@ -1,32 +1,32 @@
-<div class="bg-white rounded-lg shadow-lg mx-auto p-6 max-w-2xl">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-900/50 mx-auto mt-8 p-6 max-w-2xl">
   <svg class="h-12 w-12 text-indigo-600 mx-auto mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
   </svg>
-  <h1 class="text-3xl font-extrabold text-center">Email report</h1>
+  <h1 class="text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">Email report</h1>
 
-  <p class="my-6 text-gray-800">
+  <p class="my-6 text-gray-800 dark:text-gray-200">
     This email was sent from <span class="font-bold"><%= @sender %></span>
     to <span class="font-bold"><%= @email_alias %></span>.
   </p>
 
   <%= if not Enum.empty?(@trackers) do %>
-    <h2 class="text-xl font-bold">Trackers</h2>
+    <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Trackers</h2>
 
-    <p class="text-gray-800">Shroud.email removed the following trackers from this email:</p>
+    <p class="text-gray-800 dark:text-gray-200">Shroud.email removed the following trackers from this email:</p>
 
     <ul class="space-y-2 my-4">
       <%= for tracker <- @trackers do %>
-        <li class="block bg-slate-200 rounded p-3 font-semibold"><%= tracker %></li>
+        <li class="block bg-slate-200 dark:bg-gray-700 rounded p-3 font-semibold text-gray-900 dark:text-gray-100"><%= tracker %></li>
       <% end %>
     </ul>
 
-    <p class="text-gray-800">
+    <p class="text-gray-800 dark:text-gray-200">
       Spammers and advertisers use trackers like these to see when you opened an email, and where you
       were when you opened it. Thanks to Shroud.email, you're keeping them in the dark.
     </p>
 
   <% else %>
-    <p class="text-indigo-800 text-center font-bold mb-3">
+    <p class="text-indigo-800 dark:text-indigo-300 text-center font-bold mb-3">
       Shroud.email did not find any trackers in this email. You're all clear!
     </p>
   <% end %>


### PR DESCRIPTION
## Summary
- Add dark mode styles to the email report page (`/email-report/:data`) which was missing them entirely
- Card background, headings, body text, tracker badges, and the "no trackers" message all now have proper `dark:` variants matching the rest of the app
- Add top margin to the card so it doesn't touch the navbar

## Test plan
- [ ] Visit `/email-report/eyJzZW5kZXIiOiJqb3ZpbkBtb2JiaW4uY29tIiwidHJhY2tlcnMiOlsiTWFpbGd1biJdLCJlbWFpbF9hbGlhcyI6Im1vYmJpbkBjdXJzZWQudGVjaG5vbG9neSJ9` in dark mode and verify readability
- [ ] Verify light mode is unchanged
- [ ] Check the "no trackers" variant by visiting with an empty trackers array

🤖 Generated with [Claude Code](https://claude.com/claude-code)