### PR TITLE
ci: drop Blacksmith sticky-disk cache, use GHA cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Configure Blacksmith's BuildKit + layer cache
-      - name: Setup Blacksmith
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v2
@@ -69,13 +68,15 @@ jobs:
 
       - name: Build & push (single-arch)
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: ${{ matrix.docker_platform }}
           tags: ${{ steps.meta_arch.outputs.tags }}
           labels: ${{ steps.meta_base.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       # Save the digest produced by this job and the base tag list once
       - name: Persist digest


### PR DESCRIPTION
## Summary
- Swaps `useblacksmith/setup-docker-builder@v1` → `docker/setup-buildx-action@v3` and `useblacksmith/build-push-action@v2` → `docker/build-push-action@v6` so we stop accruing the $0.50/GB/mo sticky-disk layer-cache charge.
- Keeps the `blacksmith-4vcpu-ubuntu-2404[-arm]` runners — only the Docker-caching actions change.
- Adds GHA layer cache (`type=gha`, `mode=max`, per-platform scope) as a free-within-quota substitute so cold builds don't regress too hard.

## Context
Per Blacksmith's docs, `type=gha` is one of the few caches they don't proxy to their co-located cache (their recommendation there is to use their sticky-disk actions — which is exactly the charge we're removing). It still works, it just hits GitHub's actual cache backend; cache storage sits within the 10 GB/repo quota with LRU eviction, so no surprise bill — worst case is cache misses.

## Test plan
- [ ] Kick a `workflow_dispatch` run of Build; confirm both matrix legs pass and push multi-arch images.
- [ ] Confirm second run shows GHA cache hits (look for `importing cache manifest from gha:...` / `CACHED` layers in the build log).
- [ ] Verify merge-manifests job still produces a working multi-arch image.
- [ ] Check Blacksmith dashboard next month to confirm sticky-disk usage has dropped to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)