### PR TITLE
chore: upgrade all GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # Base (unsuffixed) tags used for final multi-arch manifest
       - name: Extract base tags
         id: meta_base
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -58,7 +58,7 @@ jobs:
       # Arch-suffixed tags pushed by each matrix job (avoids collisions)
       - name: Extract arch-suffixed tags
         id: meta_arch
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & push (single-arch)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -85,7 +85,7 @@ jobs:
         shell: bash
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.platform }}
           path: digest-${{ matrix.platform }}.txt
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload base tags (once)
         if: matrix.platform == 'amd64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tags
           path: tags.txt
@@ -112,14 +112,14 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "{tags,digest-*}"
           path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1.18.2
+        uses: erlef/setup-beam@v1.24.0
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
           version-type: "strict"
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -60,6 +60,7 @@ jobs:
         run: mix ecto.setup
       - name: Run tests
         run: mix coveralls.json
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v6
         with:
           files: ./cover/excoveralls.json
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
-          version-type: "strict"
       - name: Restore dependencies cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.PAT }}
           release-type: elixir

--- a/.github/workflows/sobelow.yml
+++ b/.github/workflows/sobelow.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1.18.2
+        uses: erlef/setup-beam@v1.24.0
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
           version-type: "strict"
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/sobelow.yml
+++ b/.github/workflows/sobelow.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
-          version-type: "strict"
       - name: Restore dependencies cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Build an image from Dockerfile
         run: |
           docker build -t ghcr.io/shroud-email/shroud.email:${{ github.sha }} .
@@ -36,6 +36,6 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

Bumps every action in `.github/workflows/` to its current latest major version. Supersedes the open dependabot PRs (#73, #74, #75, #76), which were all behind even the latest majors.

### Updated actions

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v3 / v4 | **v6** |
| `actions/setup-node` | v3 | **v6** |
| `actions/cache` | v3 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v2 | **v4** |
| `docker/metadata-action` | v4 | **v6** |
| `docker/build-push-action` | v6 | **v7** |
| `codecov/codecov-action` | v3 | **v6** |
| `googleapis/release-please-action` | v4 | **v5** |
| `github/codeql-action/upload-sarif` | v2 | **v3** |
| `erlef/setup-beam` | v1.18.2 | **v1.24.0** |
