### PR TITLE
chore: pin GitHub Actions to SHAs with ratchet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # Base (unsuffixed) tags used for final multi-arch manifest
       - name: Extract base tags
         id: meta_base
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # ratchet:docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -58,7 +58,7 @@ jobs:
       # Arch-suffixed tags pushed by each matrix job (avoids collisions)
       - name: Extract arch-suffixed tags
         id: meta_arch
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # ratchet:docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & push (single-arch)
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # ratchet:docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -85,7 +85,7 @@ jobs:
         shell: bash
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.platform }}
           path: digest-${{ matrix.platform }}.txt
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload base tags (once)
         if: matrix.platform == 'amd64'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: tags
           path: tags.txt
@@ -112,14 +112,14 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           pattern: "{tags,digest-*}"
           path: artifacts
@@ -129,7 +129,7 @@ jobs:
         env:
           REGISTRY: ${{ env.REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-        run: |
+        run: |-
           set -euo pipefail
 
           AMD_DIGEST="$(cat artifacts/digest-amd64.txt)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       LOOPS_API_KEY: secret
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: index.docker.io/library/postgres@sha256:c4c7a1585974706b5f72b8ab595e47399b23b2e03d93bbf75c1b0904be1803dc # ratchet:postgres:13.2-alpine
         ports:
           - 5432:5432
         env:
@@ -29,14 +29,14 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # ratchet:erlef/setup-beam@v1.24.0
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
       - name: Restore dependencies cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         with:
           path: |
             deps
@@ -59,7 +59,7 @@ jobs:
         run: mix ecto.setup
       - name: Run tests
         run: mix coveralls.json
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # ratchet:codecov/codecov-action@v6
         with:
           files: ./cover/excoveralls.json
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 50
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: 18
       - run: npm ci

--- a/.github/workflows/ratchet-update.yml
+++ b/.github/workflows/ratchet-update.yml
@@ -1,0 +1,41 @@
+name: Ratchet update
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install ratchet
+        run: go install github.com/sethvargo/ratchet@latest
+
+      - name: Run ratchet update
+        run: ratchet update .github/workflows/*.yml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # ratchet:peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PAT }}
+          branch: ratchet/update
+          commit-message: "chore: update pinned GitHub Actions SHAs"
+          title: "chore: update pinned GitHub Actions SHAs"
+          body: |
+            Automated weekly run of `ratchet update` to refresh pinned action SHAs
+            to the latest commit for each tagged version.
+          delete-branch: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # ratchet:googleapis/release-please-action@v5
         with:
           token: ${{ secrets.PAT }}
           release-type: elixir

--- a/.github/workflows/sobelow.yml
+++ b/.github/workflows/sobelow.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # ratchet:erlef/setup-beam@v1.24.0
         with:
           elixir-version: "1.16.3"
           otp-version: "26"
       - name: Restore dependencies cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         with:
           path: |
             deps
@@ -38,6 +38,6 @@ jobs:
       - name: Run Sobelow
         run: mix sobelow --format sarif --out results.sarif
       - name: Upload report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # ratchet:github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,10 +2,10 @@ name: Trivy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '27 7 * * 5'
 
@@ -24,18 +24,18 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Build an image from Dockerfile
         run: |
           docker build -t ghcr.io/shroud-email/shroud.email:${{ github.sha }} .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # ratchet:aquasecurity/trivy-action@master
         with:
           image-ref: ghcr.io/shroud-email/shroud.email:${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # ratchet:github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Pin every action reference in `.github/workflows/` to its commit SHA with a trailing `# ratchet:<owner>/<repo>@<tag>` comment (via `ratchet pin` + `ratchet update`), so tag mutation can't silently change what runs in CI.
- Replace the daily Dependabot `github-actions` ecosystem (whose pin comment format conflicts with ratchet's) with a weekly `ratchet update` workflow (`.github/workflows/ratchet-update.yml`) that opens a PR with any SHA bumps. Runs Mondays 06:00 UTC and on-demand via `workflow_dispatch`.
- Delete `.github/dependabot.yml` (github-actions was its only entry).

## Notes
- The update workflow uses `secrets.PAT` (same token as release-please) so the PRs it opens trigger CI.
- Requires *Settings → Actions → General → Workflow permissions* to allow Actions to create PRs — already enabled for release-please, so nothing to change.

## Test plan
- [ ] Existing workflows (CI, Sobelow, Trivy, build, commitlint, release-please) still run green on this PR
- [ ] Manually trigger `Ratchet update` via `workflow_dispatch` once merged and confirm it either no-ops or opens a clean PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)