### PR TITLE
ci: optimize Trivy scans (fs on PRs, image post-build on main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   packages: write
+  security-events: write
 
 jobs:
   build:
@@ -155,3 +156,45 @@ jobs:
               "${IMAGE_REF}@${AMD_DIGEST}" \
               "${IMAGE_REF}@${ARM_DIGEST}"
           done
+
+  scan:
+    name: Trivy image scan
+    needs: build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download amd64 digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        with:
+          name: digest-amd64
+      - name: Resolve image ref
+        id: ref
+        run: |
+          set -euo pipefail
+          DIGEST="$(cat digest-amd64.txt)"
+          IMAGE_REF="${REGISTRY}/${IMAGE_NAME}"
+          IMAGE_REF="${IMAGE_REF,,}@${DIGEST}"
+          echo "image=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # ratchet:aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.ref.outputs.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # ratchet:github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,10 +1,7 @@
 name: Trivy
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["main"]
   schedule:
     - cron: '27 7 * * 5'
@@ -12,29 +9,57 @@ on:
 permissions:
   contents: read
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
-  scan:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    name: Scan
+  fs-scan:
+    if: github.event_name == 'pull_request'
+    name: Filesystem scan
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - name: Build an image from Dockerfile
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # ratchet:aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # ratchet:github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  image-scan:
+    if: github.event_name == 'schedule'
+    name: Scheduled image scan
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve image ref
+        id: ref
         run: |
-          docker build -t ghcr.io/shroud-email/shroud.email:${{ github.sha }} .
+          SHORT="${GITHUB_SHA:0:7}"
+          echo "image=ghcr.io/shroud-email/shroud.email:sha-${SHORT}" >> "$GITHUB_OUTPUT"
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # ratchet:aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/shroud-email/shroud.email:${{ github.sha }}
+          image-ref: ${{ steps.ref.outputs.image }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL,HIGH,MEDIUM'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # ratchet:github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary
- PRs now run `trivy fs` instead of a full docker build + image scan (seconds vs ~10 min)
- main: image scan folded into `build.yml`, reuses the amd64 build digest (one build instead of two)
- Scheduled weekly scan pulls the latest main `sha-<short>` image from GHCR instead of rebuilding
- Added `MEDIUM` to severity threshold across all scans

## Test plan
- [ ] Verify `fs-scan` runs on this PR and uploads SARIF to the Security tab
- [ ] After merge to main, verify the new `scan` job in `build.yml` scans the pushed image by digest
- [ ] On the next Friday 07:27 UTC cron, verify scheduled scan resolves the latest main SHA and finds the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)