### PR TITLE
chore: upgrade tailwindcss v3 to v4

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,10 +1,28 @@
 /* This file is for your main application CSS */
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@import 'tailwindcss';
 
-@import "./components.css";
-@import "../vendor/tippy.css";
+@import './components.css' layer(utilities);
+@import '../vendor/tippy.css' layer(utilities);
+
+@config '../tailwind.config.js';
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
 
 /* Form errors from error_tag */
 .invalid-feedback {

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -12,7 +12,7 @@
 }
 
 .btn {
-  @apply inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 justify-center dark:focus:ring-offset-gray-900;
+  @apply inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-xs focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 justify-center dark:focus:ring-offset-gray-900;
 }
 .btn-primary {
   @apply text-white bg-indigo-600 hover:bg-indigo-700;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,14 +10,13 @@
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.4.1",
+        "@tailwindcss/postcss": "^4.2.4",
         "@tailwindcss/typography": "^0.5.19",
-        "autoprefixer": "^10.5.0",
         "commitizen": "^4.3.1",
         "cssnano": "^5.1.15",
         "postcss": "^8.5.10",
         "postcss-cli": "^9.1.0",
-        "postcss-import": "^14.1.0",
-        "tailwindcss": "^3.4.19"
+        "tailwindcss": "^4.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -153,6 +152,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -264,6 +274,277 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.4"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
@@ -358,13 +639,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -378,13 +652,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -415,43 +682,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -629,16 +859,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/caniuse-api": {
@@ -1160,12 +1380,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1179,13 +1402,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -1260,6 +1476,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -1290,16 +1520,6 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1466,20 +1686,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -1516,16 +1722,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -1678,19 +1874,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -1945,22 +2128,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2071,7 +2238,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2127,6 +2293,267 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2142,7 +2569,8 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -2283,6 +2711,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -2385,18 +2823,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2457,26 +2883,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/once": {
@@ -2669,13 +3075,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -2714,16 +3113,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/postcss": {
@@ -2902,50 +3291,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/postcss-import": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
     "node_modules/postcss-load-config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
@@ -3078,46 +3423,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -3484,28 +3789,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
@@ -3764,39 +4047,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3808,19 +4058,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svgo": {
@@ -3846,152 +4083,24 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "license": "MIT"
     },
-    "node_modules/tailwindcss/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/thenby": {
@@ -4001,83 +4110,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",
@@ -4113,13 +4151,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -4,14 +4,13 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.4.1",
+    "@tailwindcss/postcss": "^4.2.4",
     "@tailwindcss/typography": "^0.5.19",
-    "autoprefixer": "^10.5.0",
     "commitizen": "^4.3.1",
     "cssnano": "^5.1.15",
     "postcss": "^8.5.10",
     "postcss-cli": "^9.1.0",
-    "postcss-import": "^14.1.0",
-    "tailwindcss": "^3.4.19"
+    "tailwindcss": "^4.2.4"
   },
   "dependencies": {
     "@ryangjchandler/alpine-tooltip": "^2.0.1",

--- a/assets/postcss.config.js
+++ b/assets/postcss.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   plugins: {
-    'postcss-import': {},
-    tailwindcss: {},
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
     cssnano: {
       preset: "default",
     },

--- a/lib/shroud_web/components/atoms.ex
+++ b/lib/shroud_web/components/atoms.ex
@@ -47,7 +47,7 @@ defmodule ShroudWeb.Components.Atoms do
       type={@type}
       disabled={@disabled}
       class={@class <>
-        " inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 justify-center disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900"}
+        " inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-xs focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 justify-center disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900"}
       {@rest}
     >
       <span :if={@icon} class="-ml-1 mr-2 h-5 w-5">
@@ -92,7 +92,7 @@ defmodule ShroudWeb.Components.Atoms do
           name={@name}
           id={@name}
           placeholder={@placeholder}
-          class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
+          class="shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
         />
       </div>
     </div>
@@ -104,10 +104,10 @@ defmodule ShroudWeb.Components.Atoms do
 
   def toggle(assigns) do
     button_class =
-      "relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900"
+      "relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900"
 
     toggle_class =
-      "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
+      "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transform ring-0 transition ease-in-out duration-200"
 
     [button_class, toggle_class] =
       if assigns.on do
@@ -164,7 +164,7 @@ defmodule ShroudWeb.Components.Atoms do
 
     ~H"""
     <div class={"rounded-md p-4 flex text-sm border mb-6 " <> @alert_class}>
-      <div class="flex-shrink-0">
+      <div class="shrink-0">
         <.icon name={@icon} solid class={"text-base h-5 w-5 " <> @icon_class} />
       </div>
       <div class="ml-3">
@@ -212,12 +212,12 @@ defmodule ShroudWeb.Components.Atoms do
       :if={Phoenix.Flash.get(@flash, @kind)}
       phx-hook="Notification"
       id={"flash-#{@kind}"}
-      class="fade-in-translate max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 dark:ring-gray-700 overflow-hidden hover:shadow-xl transition-all duration-100"
+      class="fade-in-translate max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto ring-1 ring-black/5 dark:ring-gray-700 overflow-hidden hover:shadow-xl transition-all duration-100"
       phx-click={close("#flash", @kind)}
     >
       <div class="p-4">
         <div class="flex items-start">
-          <div class="flex-shrink-0">
+          <div class="shrink-0">
             <.icon name={@icon} class={"h-6 w-6 " <> @icon_class} />
           </div>
           <div class="ml-3 w-0 flex-1 pt-0.5">

--- a/lib/shroud_web/components/button_with_dropdown.ex
+++ b/lib/shroud_web/components/button_with_dropdown.ex
@@ -26,12 +26,12 @@ defmodule ShroudWeb.Components.ButtonWithDropdown do
     assigns = assign(assigns, :class, class)
 
     ~H"""
-    <div class="inline-flex rounded-md shadow-sm">
+    <div class="inline-flex rounded-md shadow-xs">
       <button
         phx-click={@click}
         type="button"
         class={@class <>
-          " relative inline-flex items-center rounded-l-md border px-4 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"}
+          " relative inline-flex items-center rounded-l-md border px-4 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-hidden focus:ring-1 focus:ring-indigo-500"}
       >
         <span :if={@icon} class="-ml-1 mr-2 h-5 w-5">
           <.icon solid name={@icon} />
@@ -41,7 +41,7 @@ defmodule ShroudWeb.Components.ButtonWithDropdown do
       <.dropdown_menu
         class="-ml-px block"
         button_class={@class <>
-          " relative inline-flex items-center rounded-r-md border px-2 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"}
+          " relative inline-flex items-center rounded-r-md border px-2 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-hidden focus:ring-1 focus:ring-indigo-500"}
         disabled={@disabled}
       >
         <:button_content>

--- a/lib/shroud_web/components/dns_verification.ex
+++ b/lib/shroud_web/components/dns_verification.ex
@@ -43,7 +43,7 @@ defmodule ShroudWeb.Components.DnsVerification do
       <div class="mt-4 flex flex-col">
         <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
           <div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
-            <div class="overflow-hidden shadow dark:shadow-gray-900/50 ring-1 ring-black ring-opacity-5 dark:ring-gray-700 md:rounded-lg">
+            <div class="overflow-hidden shadow-sm dark:shadow-gray-900/50 ring-1 ring-black/5 dark:ring-gray-700 md:rounded-lg">
               <table class="min-w-full">
                 <thead class="bg-white dark:bg-gray-800">
                   <tr>

--- a/lib/shroud_web/components/dropdown_menu.ex
+++ b/lib/shroud_web/components/dropdown_menu.ex
@@ -42,7 +42,7 @@ defmodule ShroudWeb.Components.DropdownMenu do
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="origin-top-right absolute right-0 z-10 flex flex-col mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 dark:ring-gray-700 focus:outline-none"
+        class="origin-top-right absolute right-0 z-10 flex flex-col mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black/5 dark:ring-gray-700 focus:outline-hidden"
         x-ref="menu-items"
         x-bind:aria-activedescendant="activeDescendant"
         role="menu"

--- a/lib/shroud_web/components/layouts/live.html.heex
+++ b/lib/shroud_web/components/layouts/live.html.heex
@@ -1,4 +1,4 @@
-<header class="bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50">
+<header class="bg-white dark:bg-gray-800 shadow-xs dark:shadow-gray-900/50">
     <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex items-center">
     <%= if @page_title_url do %>
         <.link navigate={@page_title_url} class="text-gray-900 dark:text-gray-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
@@ -12,7 +12,7 @@
         </h1>
     <% end %>
     <%= if @subpage_title do %>
-        <.icon name={:chevron_right} solid class="flex-shrink-0 h-5 w-5 text-gray-500 dark:text-gray-400 ml-1" />
+        <.icon name={:chevron_right} solid class="shrink-0 h-5 w-5 text-gray-500 dark:text-gray-400 ml-1" />
         <h2 class="text-sm text-gray-700 dark:text-gray-300 ml-1"><%= @subpage_title %></h2>
     <% end %>
     </div>

--- a/lib/shroud_web/components/layouts/navbar.html.heex
+++ b/lib/shroud_web/components/layouts/navbar.html.heex
@@ -3,7 +3,7 @@
     <div class="border-b border-gray-700">
       <div class="flex items-center justify-between h-16 px-4 sm:px-0">
         <div class="flex items-center">
-          <div class="flex-shrink-0 text-gray-200 flex items-center">
+          <div class="shrink-0 text-gray-200 flex items-center">
             <img class="inline w-6 h-6 mr-3 text-indigo-400" src={~p"/images/logo.svg"} alt="Shroud.email logo" />
             <span class="whitespace-nowrap font-semibold text-lg">Shroud.email</span>
           </div>
@@ -45,7 +45,7 @@
                 <div>
                   <button
                     type="button"
-                    class="max-w-xs bg-gray-800 rounded-full flex items-center text-sm text-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+                    class="max-w-xs bg-gray-800 rounded-full flex items-center text-sm text-gray-300 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
                     id="user-menu-button"
                     aria-haspopup="true"
                     x-ref="button"
@@ -74,7 +74,7 @@
           <button
             @click="open = !open"
             type="button"
-            class="bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+            class="bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
             aria-controls="mobile-menu"
             x-bind:aria-expanded="open.toString()"
           >
@@ -123,7 +123,7 @@
     <div class="pt-4 pb-3 border-t border-gray-700">
       <%= if @current_user do %>
         <div class="flex items-center px-5">
-          <div class="flex-shrink-0 text-gray-400">
+          <div class="shrink-0 text-gray-400">
             <!-- HeroIcons user-cirle -->
             <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/lib/shroud_web/components/layouts/settings.html.heex
+++ b/lib/shroud_web/components/layouts/settings.html.heex
@@ -21,7 +21,7 @@
           <.icon name={:user_circle} class={active_class(
             @conn,
             ~p"/settings/account",
-            "text-gray-400 group-hover:text-gray-500 flex-shrink-0 -ml-1 mr-3 h-6 w-6",
+            "text-gray-400 group-hover:text-gray-500 shrink-0 -ml-1 mr-3 h-6 w-6",
             "text-indigo-500 group-hover:text-indigo-500"
           )} />
           <span class="truncate">
@@ -41,7 +41,7 @@
           <.icon name={:key} class={active_class(
             @conn,
             ~p"/settings/security",
-            "text-gray-400 group-hover:text-gray-500 flex-shrink-0 -ml-1 mr-3 h-6 w-6",
+            "text-gray-400 group-hover:text-gray-500 shrink-0 -ml-1 mr-3 h-6 w-6",
             "text-indigo-500 group-hover:text-indigo-500"
           )} />
           <span class="truncate">
@@ -61,7 +61,7 @@
           <.icon name={:paint_brush} class={active_class(
             @conn,
             ~p"/settings/appearance",
-            "text-gray-400 group-hover:text-gray-500 flex-shrink-0 -ml-1 mr-3 h-6 w-6",
+            "text-gray-400 group-hover:text-gray-500 shrink-0 -ml-1 mr-3 h-6 w-6",
             "text-indigo-500 group-hover:text-indigo-500"
           )} />
           <span class="truncate">
@@ -81,7 +81,7 @@
           <.icon name={:credit_card} class={active_class(
             @conn,
             ~p"/settings/billing",
-            "text-gray-400 group-hover:text-gray-500 flex-shrink-0 -ml-1 mr-3 h-6 w-6",
+            "text-gray-400 group-hover:text-gray-500 shrink-0 -ml-1 mr-3 h-6 w-6",
             "text-indigo-500 group-hover:text-indigo-500"
           )} />
           <span class="truncate">

--- a/lib/shroud_web/components/layouts/user_menu_desktop.html.heex
+++ b/lib/shroud_web/components/layouts/user_menu_desktop.html.heex
@@ -6,7 +6,7 @@
   x-transition:leave="transition ease-in duration-75"
   x-transition:leave-start="transform opacity-100 scale-100"
   x-transition:leave-end="transform opacity-0 scale-95"
-  class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 dark:ring-gray-700 focus:outline-none"
+  class="origin-top-right absolute right-0 z-10 mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black/5 dark:ring-gray-700 focus:outline-hidden"
   x-ref="menu-items"
   x-description="Dropdown menu, show/hide based on menu state."
   x-bind:aria-activedescendant="activeDescendant"

--- a/lib/shroud_web/components/popup_alert.ex
+++ b/lib/shroud_web/components/popup_alert.ex
@@ -46,7 +46,7 @@ defmodule ShroudWeb.Components.PopupAlert do
           x-transition:leave="ease-in duration-200"
           x-transition:leave-start="opacity-100"
           x-transition:leave-end="opacity-0"
-          class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80 transition-opacity"
+          class="fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80 transition-opacity"
         />
 
         <div class="fixed z-10 inset-0 overflow-y-auto">
@@ -68,7 +68,7 @@ defmodule ShroudWeb.Components.PopupAlert do
             >
               <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                 <div class="sm:flex sm:items-start">
-                  <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 dark:bg-gray-700 sm:mx-0 sm:h-10 sm:w-10">
+                  <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 dark:bg-gray-700 sm:mx-0 sm:h-10 sm:w-10">
                     <.icon name={@icon} class="h-6 w-6 text-gray-600 dark:text-gray-400" />
                   </div>
                   <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">

--- a/lib/shroud_web/controllers/error_html/error_page.html.heex
+++ b/lib/shroud_web/controllers/error_html/error_page.html.heex
@@ -1,6 +1,6 @@
 <div id="fog" class="min-h-full pt-16 pb-12 flex flex-col bg-gray-800">
-  <main class="flex-grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="flex-shrink-0 flex justify-center">
+  <main class="grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="shrink-0 flex justify-center">
       <a href="/" class="inline-flex">
         <span class="sr-only">Shroud.email</span>
         <img class="h-12 w-auto text-indigo-400" src="/images/logo.svg" alt="Shroud.email logo" />
@@ -17,7 +17,7 @@
       </div>
     </div>
   </main>
-  <footer class="flex-shrink-0 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
+  <footer class="shrink-0 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
     <nav class="flex justify-center space-x-4">
       <a href="mailto:hello@shroud.email" class="text-sm font-medium text-gray-300 hover:text-gray-400">Contact Support</a>
       <span class="inline-block border-l border-gray-500" aria-hidden="true"></span>

--- a/lib/shroud_web/controllers/user_confirmation_html/edit.html.heex
+++ b/lib/shroud_web/controllers/user_confirmation_html/edit.html.heex
@@ -6,7 +6,7 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={_f} for={%{}} as={:user} action={~p"/users/confirm/#{@token}"}>
         <%= submit "Confirm my account", class: "btn btn-primary w-full" %>
       </.form>

--- a/lib/shroud_web/controllers/user_confirmation_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_confirmation_html/new.html.heex
@@ -6,7 +6,7 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <p class="prose dark:text-gray-300">
         We sent you an email with a confirmation link.
         Please click the link in this email to continue.

--- a/lib/shroud_web/controllers/user_registration_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_registration_html/new.html.heex
@@ -16,7 +16,7 @@
   <% end %>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={f} for={@changeset} action={~p"/users/register"} as={:user} class="space-y-6">
         <%= if @lifetime do %>
           <p class="text-sm text-gray-600 dark:text-gray-400 text-center">Signing up for a lifetime account.</p>
@@ -25,7 +25,7 @@
         <div>
           <%= label f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= email_input f, :email, required: true, autocomplete: "email",  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= email_input f, :email, required: true, autocomplete: "email",  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :email %>
           </div>
         </div>
@@ -33,7 +33,7 @@
         <div>
           <%= label f, :password, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :password %>
           </div>
         </div>

--- a/lib/shroud_web/controllers/user_reset_password_html/edit.html.heex
+++ b/lib/shroud_web/controllers/user_reset_password_html/edit.html.heex
@@ -10,12 +10,12 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={f} for={@changeset} action={~p"/users/reset_password/@token"} class="space-y-6">
         <div>
           <%= label f, :password, "New password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :password %>
           </div>
         </div>
@@ -23,7 +23,7 @@
         <div>
           <%= label f, :password_confirmation, "Confirm new password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password_confirmation, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password_confirmation, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :password_confirmation %>
           </div>
         </div>

--- a/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
@@ -10,12 +10,12 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={f} for={%{}} as={:user} action={~p"/users/reset_password"} class="space-y-6">
         <div>
           <%= label f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= email_input f, :email, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= email_input f, :email, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
 

--- a/lib/shroud_web/controllers/user_session_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_session_html/new.html.heex
@@ -10,7 +10,7 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={f} for={@conn} action={~p"/users/log_in"} as={:user} class="space-y-6">
         <%= if @error_message do %>
           <div class="alert alert-error">
@@ -23,14 +23,14 @@
         <div>
           <%= label f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= email_input f, :email, required: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= email_input f, :email, required: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
 
         <div>
           <%= label f, :password, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password, required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
 

--- a/lib/shroud_web/controllers/user_session_html/totp.html.heex
+++ b/lib/shroud_web/controllers/user_session_html/totp.html.heex
@@ -10,7 +10,7 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
+    <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
       <.form :let={f} for={@conn} action={~p"/users/totp"} as={:user} class="space-y-6">
         <%= hidden_input f, :action, name: "action", value: "totp" %>
 
@@ -19,7 +19,7 @@
         <div>
           <%= label f, :verification_code, for: "verification_code", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 8, name: "verification_code", id: "verification_code", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 8, name: "verification_code", id: "verification_code", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs placeholder-gray-400 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
 

--- a/lib/shroud_web/controllers/user_settings_html/account.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/account.html.heex
@@ -1,5 +1,5 @@
 <.form :let={f} for={@email_changeset} action={~p"/settings"} id="update_email">
-  <div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
+  <div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
     <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
       <div>
         <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Email</h3>
@@ -16,16 +16,16 @@
 
         <div class="col-span-3">
           <%= label f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-          <div class="mt-1 rounded-md shadow-sm flex">
-            <%= email_input f, :email, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+          <div class="mt-1 rounded-md shadow-xs flex">
+            <%= email_input f, :email, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
         <%= error_tag f, :email %>
 
         <div class="col-span-3 mt-6">
           <%= label f, :current_password, for: "current_password_for_email", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-          <div class="mt-1 rounded-md shadow-sm flex">
-            <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_email", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+          <div class="mt-1 rounded-md shadow-xs flex">
+            <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_email", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           </div>
         </div>
         <%= error_tag f, :current_password %>

--- a/lib/shroud_web/controllers/user_settings_html/appearance.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/appearance.html.heex
@@ -1,4 +1,4 @@
-<div class="shadow sm:rounded-md sm:overflow-hidden">
+<div class="shadow-sm sm:rounded-md sm:overflow-hidden">
   <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
     <div>
       <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Theme</h3>

--- a/lib/shroud_web/controllers/user_settings_html/billing.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/billing.html.heex
@@ -1,6 +1,6 @@
 <%= cond do %>
 <% @current_user.status == :lifetime -> %>
-  <div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
+  <div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
     <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
       <div>
         <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Billing</h3>
@@ -11,7 +11,7 @@
     </div>
   </div>
 <% @current_user.status == :free -> %>
-  <div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden mb-6">
+  <div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden mb-6">
     <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
       <div>
         <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Free Plan</h3>
@@ -26,7 +26,7 @@
 <% is_nil(@current_user.stripe_customer_id) -> %>
   <.signup {assigns} />
 <% true -> %>
-  <div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
+  <div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
     <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
       <div>
         <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Billing</h3>

--- a/lib/shroud_web/controllers/user_settings_html/lifetime.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/lifetime.html.heex
@@ -5,11 +5,11 @@
   <%= form_for @conn, ~p"/settings/billing/lifetime", [class: "mt-8"], fn f -> %>
 
     <%= label f, :lifetime_code, "Code", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-    <%= text_input f, :lifetime_code, required: true, class: "mt-1 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+    <%= text_input f, :lifetime_code, required: true, class: "mt-1 shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
     <p class="my-2 text-sm text-gray-500 dark:text-gray-400">
       Please enter the lifetime subscription code you purchased.
     </p>
 
-    <%= submit "Sign up", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+    <%= submit "Sign up", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
   <% end %>
 </div>

--- a/lib/shroud_web/controllers/user_settings_html/security.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/security.html.heex
@@ -1,5 +1,5 @@
 <.form :let={f} for={@password_changeset} action={~p"/settings"} id="update_password">
-  <div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
+  <div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
     <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
       <div>
         <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Password</h3>
@@ -12,7 +12,7 @@
         <div class="col-span-3">
           <%= label f, :password, "New password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :password %>
           </div>
         </div>
@@ -20,7 +20,7 @@
         <div class="col-span-3">
           <%= label f, :password_confirmation, "Confirm new password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :password_confirmation, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :password_confirmation, required: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :password_confirmation %>
           </div>
         </div>
@@ -28,7 +28,7 @@
         <div class="col-span-3">
           <%= label f, :current_password, for: "current_password_for_password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">
-            <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+            <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
             <%= error_tag f, :current_password %>
           </div>
         </div>
@@ -40,7 +40,7 @@
   </div>
 </.form>
 
-<div class="shadow dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
+<div class="shadow-sm dark:shadow-gray-900/50 sm:rounded-md sm:overflow-hidden">
   <div class="bg-white dark:bg-gray-800 py-6 px-4 space-y-6 sm:p-6">
     <div>
       <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Two-factor authentication</h3>
@@ -77,7 +77,7 @@
 
         <div class="w-64 mx-auto">
           <%= label f, :verification_code, for: "verification_code", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-          <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 6, name: "verification_code", id: "verification_code", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+          <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 6, name: "verification_code", id: "verification_code", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
         </div>
 
         <div class="text-right mt-6">
@@ -111,7 +111,7 @@
           <%= hidden_input f, :action, name: "action", value: "disable_totp" %>
 
           <%= label f, :verification_code, for: "verification_code", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-          <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 8, name: "verification_code", id: "verification_code", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
+          <%= number_input f, :verification_code, required: true, minlength: 6, maxlength: 8, name: "verification_code", id: "verification_code", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-xs py-2 px-3 focus:outline-hidden focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400" %>
           <div class="mt-6 text-right">
             <%= submit "Disable two-factor authentication", class: "btn btn-primary" %>
           </div>

--- a/lib/shroud_web/controllers/user_settings_html/signup.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/signup.html.heex
@@ -3,22 +3,22 @@
     <button
       @click="billingPeriod = 'monthly'"
       type="button"
-      x-bind:class="billingPeriod === 'monthly' ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 shadow-sm' : 'border-transparent text-gray-700 dark:text-gray-300'"
-      class="relative w-1/2 border rounded-md shadow-sm py-2 text-sm font-medium whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:z-10 sm:w-auto sm:px-8"
+      x-bind:class="billingPeriod === 'monthly' ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 shadow-xs' : 'border-transparent text-gray-700 dark:text-gray-300'"
+      class="relative w-1/2 border rounded-md shadow-xs py-2 text-sm font-medium whitespace-nowrap focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:z-10 sm:w-auto sm:px-8"
     >
       Monthly billing
     </button>
     <button
       @click="billingPeriod = 'yearly'"
       type="button"
-      x-bind:class="billingPeriod === 'yearly' ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 shadow-sm' : 'border-transparent text-gray-700 dark:text-gray-300'"
-      class="ml-0.5 relative w-1/2 border rounded-md py-2 text-sm font-medium whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:z-10 sm:w-auto sm:px-8"
+      x-bind:class="billingPeriod === 'yearly' ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 shadow-xs' : 'border-transparent text-gray-700 dark:text-gray-300'"
+      class="ml-0.5 relative w-1/2 border rounded-md py-2 text-sm font-medium whitespace-nowrap focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:z-10 sm:w-auto sm:px-8"
     >
       Yearly billing
     </button>
   </div>
 
-  <div class="max-w-lg mx-auto rounded-lg shadow dark:shadow-gray-900/50 overflow-hidden lg:max-w-none lg:flex">
+  <div class="max-w-lg mx-auto rounded-lg shadow-sm dark:shadow-gray-900/50 overflow-hidden lg:max-w-none lg:flex">
     <div class="flex-1 bg-white dark:bg-gray-800 px-6 py-8 lg:px-12 lg:pb-12">
       <h3 class="text-2xl font-extrabold text-gray-900 dark:text-gray-100 sm:text-3xl">
         Upgrade to Pro
@@ -28,14 +28,14 @@
       </p>
       <div class="mt-8">
         <div class="flex items-center">
-          <h4 class="flex-shrink-0 pr-4 bg-white dark:bg-gray-800 text-sm tracking-wider font-semibold uppercase text-indigo-600 dark:text-indigo-400">
+          <h4 class="shrink-0 pr-4 bg-white dark:bg-gray-800 text-sm tracking-wider font-semibold uppercase text-indigo-600 dark:text-indigo-400">
             What's included
           </h4>
           <div class="flex-1 border-t-2 border-gray-200 dark:border-gray-600"></div>
         </div>
         <ul role="list" class="mt-8 space-y-5 lg:space-y-0 lg:grid lg:grid-cols-2 lg:gap-x-8 lg:gap-y-5">
           <li class="flex items-start lg:col-span-1">
-            <div class="flex-shrink-0">
+            <div class="shrink-0">
               <!-- Heroicon name: solid/check-circle -->
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
@@ -47,7 +47,7 @@
           </li>
 
           <li class="flex items-start lg:col-span-1">
-            <div class="flex-shrink-0">
+            <div class="shrink-0">
               <!-- Heroicon name: solid/check-circle -->
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
@@ -59,7 +59,7 @@
           </li>
 
           <li class="flex items-start lg:col-span-1">
-            <div class="flex-shrink-0">
+            <div class="shrink-0">
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
               </svg>
@@ -70,7 +70,7 @@
           </li>
 
           <li class="flex items-start lg:col-span-1">
-            <div class="flex-shrink-0">
+            <div class="shrink-0">
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
               </svg>
@@ -82,7 +82,7 @@
         </ul>
       </div>
     </div>
-    <div class="py-8 px-6 text-center bg-gray-50 dark:bg-gray-700 lg:flex-shrink-0 lg:flex lg:flex-col lg:justify-center lg:p-12">
+    <div class="py-8 px-6 text-center bg-gray-50 dark:bg-gray-700 lg:shrink-0 lg:flex lg:flex-col lg:justify-center lg:p-12">
       <p x-text="'Billed ' + billingPeriod" class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
       </p>
       <div class="mt-4 flex items-center justify-center text-5xl font-extrabold text-gray-900 dark:text-gray-100">
@@ -93,7 +93,7 @@
         </span>
       </div>
       <div class="mt-6">
-        <div class="rounded-md shadow">
+        <div class="rounded-md shadow-sm">
           <template x-if="billingPeriod === 'monthly'">
             <.link href={~p"/checkout?period=monthly"} class="flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-gray-800 hover:bg-gray-900">Upgrade</.link>
           </template>

--- a/lib/shroud_web/live/custom_domain_live/index.ex
+++ b/lib/shroud_web/live/custom_domain_live/index.ex
@@ -42,7 +42,7 @@ defmodule ShroudWeb.CustomDomainLive.Index do
           <.link
             :for={domain <- @domains}
             navigate={~p"/domains/#{domain.domain}"}
-            class="rounded bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 hover:shadow-lg transition-shadow p-3 overflow-hidden focus:ring focus:ring-indigo-600"
+            class="rounded bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 hover:shadow-lg transition-shadow-sm p-3 overflow-hidden focus:ring focus:ring-indigo-600"
           >
             <h3 class="font-bold flex items-center text-gray-900 dark:text-gray-100">
               {domain.domain}

--- a/lib/shroud_web/live/custom_domain_live/show.ex
+++ b/lib/shroud_web/live/custom_domain_live/show.ex
@@ -48,7 +48,7 @@ defmodule ShroudWeb.CustomDomainLive.Show do
         Your domain is verified and you can create aliases @{@domain.domain}.
       </p>
       <h3 class="font-semibold text-lg text-gray-900 dark:text-gray-100 mb-4">Catch-all</h3>
-      <div class="bg-white dark:bg-gray-800 rounded shadow dark:shadow-gray-900/50 md:rounded-lg ring-1 ring-black ring-opacity-5 dark:ring-gray-700 p-4 mb-12">
+      <div class="bg-white dark:bg-gray-800 rounded shadow-sm dark:shadow-gray-900/50 md:rounded-lg ring-1 ring-black/5 dark:ring-gray-700 p-4 mb-12">
         <div class="flex items-center">
           <.toggle on={@domain.catchall_enabled} click="toggle_catchall" />
           <label class="ml-3 font-semibold text-sm text-gray-900 dark:text-gray-100">
@@ -76,7 +76,7 @@ defmodule ShroudWeb.CustomDomainLive.Show do
       }
     />
     <h3 class="font-semibold text-lg text-gray-900 dark:text-gray-100 mb-4 mt-8">Danger zone</h3>
-    <div class="bg-white dark:bg-gray-800 rounded shadow dark:shadow-gray-900/50 md:rounded-lg ring-1 ring-black ring-opacity-5 dark:ring-gray-700 p-4 mb-12">
+    <div class="bg-white dark:bg-gray-800 rounded shadow-sm dark:shadow-gray-900/50 md:rounded-lg ring-1 ring-black/5 dark:ring-gray-700 p-4 mb-12">
       <.button intent={:danger} click="open_delete_modal" text="Delete domain" icon={:trash} />
     </div>
 

--- a/lib/shroud_web/live/debug_emails/index.ex
+++ b/lib/shroud_web/live/debug_emails/index.ex
@@ -22,7 +22,7 @@ defmodule ShroudWeb.DebugEmailsLive.Index do
     ~H"""
     <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+        <div class="overflow-hidden shadow-sm ring-1 ring-black/5 sm:rounded-lg">
           <table class="min-w-full divide-y divide-gray-300">
             <thead class="bg-gray-50">
               <tr>

--- a/lib/shroud_web/live/email_alias_live/index.html.heex
+++ b/lib/shroud_web/live/email_alias_live/index.html.heex
@@ -67,7 +67,7 @@
             type="text"
             name="query"
             id="query"
-            class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full text-sm border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 px-4 rounded-full"
+            class="shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full text-sm border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 px-4 rounded-full"
             placeholder="Filter"
           />
           <button type="submit" class="hidden">Apply filter</button>
@@ -92,7 +92,7 @@
   <div class="flex flex-col">
     <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-        <div class="shadow dark:shadow-gray-900/50 overflow-hidden border-b border-gray-200 dark:border-gray-700 sm:rounded-lg">
+        <div class="shadow-sm dark:shadow-gray-900/50 overflow-hidden border-b border-gray-200 dark:border-gray-700 sm:rounded-lg">
           <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead class="bg-gray-50 dark:bg-gray-700">
               <tr>

--- a/lib/shroud_web/live/email_alias_live/show.ex
+++ b/lib/shroud_web/live/email_alias_live/show.ex
@@ -27,7 +27,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
   def render(assigns) do
     ~H"""
     <div>
-      <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 overflow-hidden sm:rounded-lg">
+      <div class="bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 overflow-hidden sm:rounded-lg">
         <div class="px-4 py-5 sm:px-6">
           <div class="flex flex-col sm:flex-row items-center w-full">
             <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
@@ -80,24 +80,24 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                     "x-show": "editingTitle",
                     placeholder: "Alias title",
                     class:
-                      "flex-grow shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 rounded-md"
+                      "grow shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 rounded-md"
                   )}
-                  <span x-show="!editingTitle" class="flex-grow">
+                  <span x-show="!editingTitle" class="grow">
                     {@alias.title || "No title yet"}
                   </span>
-                  <span class="ml-4 flex-shrink-0">
+                  <span class="ml-4 shrink-0">
                     <button
                       @click="editingTitle = true"
                       x-show="!editingTitle"
                       type="button"
-                      class="bg-white dark:bg-gray-800 rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      class="bg-white dark:bg-gray-800 rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                     >
                       Update
                     </button>
                     <button
                       type="submit"
                       x-show="editingTitle"
-                      class="bg-white dark:bg-gray-800 rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      class="bg-white dark:bg-gray-800 rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                     >
                       Save
                     </button>
@@ -113,24 +113,24 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                     "x-show": "editingNotes",
                     placeholder: "Notes about this alias",
                     class:
-                      "shadow-sm block w-full focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 rounded-md"
+                      "shadow-xs block w-full focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 rounded-md"
                   )}
-                  <span x-show="!editingNotes" class="flex-grow">
+                  <span x-show="!editingNotes" class="grow">
                     {@alias.notes || "No notes"}
                   </span>
-                  <span class="ml-4 flex-shrink-0">
+                  <span class="ml-4 shrink-0">
                     <button
                       @click="editingNotes = true"
                       x-show="!editingNotes"
                       type="button"
-                      class="bg-white dark:bg-transparent rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      class="bg-white dark:bg-transparent rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                     >
                       Update
                     </button>
                     <button
                       type="submit"
                       x-show="editingNotes"
-                      class="bg-white dark:bg-transparent rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      class="bg-white dark:bg-transparent rounded-md font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-400 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                     >
                       Save
                     </button>
@@ -149,9 +149,9 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                 <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100 sm:mt-0 sm:col-span-2">
                   <form phx-submit="update_recipient">
                     <fieldset class="bg-white dark:bg-gray-800">
-                      <div class="mt-1 rounded-md shadow-sm -space-y-px">
-                        <div class="mt-1 flex rounded-t-md shadow-sm">
-                          <div class="relative flex items-stretch flex-grow focus-within:z-10">
+                      <div class="mt-1 rounded-md shadow-xs -space-y-px">
+                        <div class="mt-1 flex rounded-t-md shadow-xs">
+                          <div class="relative flex items-stretch grow focus-within:z-10">
                             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                               <.icon name={:at_symbol} solid class="h-5 w-5 text-gray-400" />
                             </div>
@@ -165,7 +165,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                           </div>
                           <button
                             type="submit"
-                            class="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-tr-md text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                            class="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-tr-md text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
                           >
                             Generate
                           </button>
@@ -227,12 +227,12 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                     class="pl-3 pr-4 py-3 flex items-center justify-between text-sm"
                   >
                     <div class="w-0 flex-1 flex items-center">
-                      <.icon name={:envelope} solid class="flex-shrink-0 h-5 w-5 text-gray-400" />
+                      <.icon name={:envelope} solid class="shrink-0 h-5 w-5 text-gray-400" />
                       <span class="ml-2 flex-1 w-0 truncate">
                         {blocked_sender}
                       </span>
                     </div>
-                    <div class="ml-4 flex-shrink-0">
+                    <div class="ml-4 shrink-0">
                       <button
                         phx-click="unblock_sender"
                         phx-value-sender={blocked_sender}
@@ -248,8 +248,8 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                 <form phx-submit="block_sender">
                   <div>
                     <label for="sender" class="sr-only">Block an address</label>
-                    <div class="mt-1 flex rounded-md shadow-sm">
-                      <div class="relative flex items-stretch flex-grow focus-within:z-10">
+                    <div class="mt-1 flex rounded-md shadow-xs">
+                      <div class="relative flex items-stretch grow focus-within:z-10">
                         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                           <.icon name={:no_symbol} solid class="h-5 w-5 text-gray-400" />
                         </div>
@@ -263,7 +263,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
                       </div>
                       <button
                         type="submit"
-                        class="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-r-md text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                        class="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-r-md text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
                       >
                         Block
                       </button>
@@ -279,7 +279,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
         </div>
       </div>
       <dl class="grid grid-cols-1 gap-5 xl:grid-cols-4 mt-6">
-        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
+        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
           <dt class="text-sm font-medium text-green-700 dark:text-green-300 truncate">
             Emails forwarded
           </dt>
@@ -291,7 +291,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
           </div>
         </div>
 
-        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
+        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
           <dt class="text-sm font-medium text-green-700 dark:text-green-300 truncate">
             Replies sent
           </dt>
@@ -303,7 +303,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
           </div>
         </div>
 
-        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
+        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
           <dt class="text-sm font-medium text-red-800 dark:text-red-300 truncate">
             Emails blocked
           </dt>
@@ -315,7 +315,7 @@ defmodule ShroudWeb.EmailAliasLive.Show do
           </div>
         </div>
 
-        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
+        <div class="px-4 py-5 bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 rounded-lg overflow-hidden sm:p-6">
           <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
             Created
           </dt>

--- a/lib/shroud_web/live/spam_email_live/index.html.heex
+++ b/lib/shroud_web/live/spam_email_live/index.html.heex
@@ -1,4 +1,4 @@
-<div class="rounded-lg bg-white dark:bg-gray-800 shadow-sm p-3 mb-6 flex flex-row">
+<div class="rounded-lg bg-white dark:bg-gray-800 shadow-xs p-3 mb-6 flex flex-row">
   <svg
     xmlns="http://www.w3.org/2000/svg"
     class="h-6 w-6 text-gray-500 dark:text-gray-400 mr-3"
@@ -45,7 +45,7 @@
     <span class="mt-2 block text-sm font-medium text-gray-900 dark:text-gray-100">No spam to deal with. Nice!</span>
   </div>
 <% else %>
-  <div :for={spam_email <- @spam_emails} class="rounded-lg bg-white dark:bg-gray-800 shadow dark:shadow-gray-900/50 mb-4">
+  <div :for={spam_email <- @spam_emails} class="rounded-lg bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900/50 mb-4">
     <div class="px-4 py-5 border-b border-gray-200 dark:border-gray-700 sm:px-6">
       <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-nowrap">
         <div class="ml-4 mt-4">
@@ -67,7 +67,7 @@
         </div>
         <div
           x-data={"{ deleteTooltip: 'Delete email', blockTooltip: 'Block #{spam_email.from}' }"}
-          class="ml-4 mt-4 flex-shrink-0 flex items-center space-x-2"
+          class="ml-4 mt-4 shrink-0 flex items-center space-x-2"
         >
           <%= if spam_email.from in spam_email.email_alias.blocked_addresses do %>
             <p class="text-red-900 dark:text-red-400 text-xs max-w-sm">
@@ -80,7 +80,7 @@
               phx-value-alias={spam_email.email_alias.address}
               x-tooltip="blockTooltip"
               type="button"
-              class="relative inline-flex items-center p-2 border border-gray-50 dark:border-gray-700 shadow text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              class="relative inline-flex items-center p-2 border border-gray-50 dark:border-gray-700 shadow-sm text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
               <span class="sr-only">Block <%= spam_email.from %></span>
               <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -98,7 +98,7 @@
             x-tooltip="deleteTooltip"
             data-confirm="Are you sure you want to delete this email?"
             type="button"
-            class="relative inline-flex items-center p-2 border border-gray-50 dark:border-gray-700 shadow text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            class="relative inline-flex items-center p-2 border border-gray-50 dark:border-gray-700 shadow-sm text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
           >
             <span class="sr-only">Delete email</span>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
## Summary

- Swaps the PostCSS pipeline to `@tailwindcss/postcss` (drops `postcss-import` and `autoprefixer`, which v4 handles internally)
- Migrates template classes to v4 equivalents across 28 template files: `flex-shrink-*`/`flex-grow-*` → `shrink-*`/`grow-*`, `outline-none` → `outline-hidden`, `shadow-sm` → `shadow-xs`, bare `shadow` → `shadow-sm`, `ring-*/bg-* + *-opacity-N` pairs → slash syntax
- Keeps the v3 border-color compat shim in `app.css` so unstyled `border` utilities continue to render as `gray-200` instead of `currentcolor` — removal can be a future cleanup PR once each implicit use has an explicit `border-<color>` companion
- Fixes a latent stacking bug in `user_menu_desktop` (dropdown had no z-index, worked in v3 by paint-order luck; now explicitly `z-10` matching `dropdown_menu.ex`)
