### PR TITLE
test: add extensive billing webhook tests

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,10 +6,14 @@ end
 
 config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET")
 
-config :shroud, :billing,
-  stripe_yearly_price: System.get_env("STRIPE_YEARLY_PRICE"),
-  stripe_monthly_price: System.get_env("STRIPE_MONTHLY_PRICE"),
-  stripe_webhook_secret: System.get_env("STRIPE_WEBHOOK_SECRET")
+# In the test env, billing config (incl. a fixed webhook secret) comes from
+# config/test.exs instead of these env vars.
+if config_env() != :test do
+  config :shroud, :billing,
+    stripe_yearly_price: System.get_env("STRIPE_YEARLY_PRICE"),
+    stripe_monthly_price: System.get_env("STRIPE_MONTHLY_PRICE"),
+    stripe_webhook_secret: System.get_env("STRIPE_WEBHOOK_SECRET")
+end
 
 # ex_aws configured with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 # environment variables in addition to this one

--- a/config/test.exs
+++ b/config/test.exs
@@ -58,3 +58,6 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :shroud,
   notifier_webhook_url: "webhook.com/webhook"
+
+# Used by the Stripe webhook controller to verify signatures in tests.
+config :shroud, :billing, stripe_webhook_secret: "whsec_test_secret_123"

--- a/test/shroud_web/controllers/checkout_controller_test.exs
+++ b/test/shroud_web/controllers/checkout_controller_test.exs
@@ -1,27 +1,268 @@
 defmodule ShroudWeb.CheckoutControllerTest do
-  use Shroud.DataCase, async: false
+  use ShroudWeb.ConnCase, async: true
+  use Oban.Testing, repo: Shroud.Repo
 
   import Shroud.AccountsFixtures
+  import ExUnit.CaptureLog
 
   alias Shroud.{Accounts, Repo}
   alias Shroud.Accounts.User
 
-  describe "update_subscription_status (via webhook)" do
-    test "sets user to :free when subscription is canceled" do
-      user = user_fixture(%{status: :active})
+  # Configured in config/test.exs; the controller verifies signatures against it.
+  @webhook_secret Application.compile_env!(:shroud, [:billing, :stripe_webhook_secret])
+  @webhook_path "/api/webhooks/stripe"
+  # 2030-01-01T00:00:00Z
+  @period_end_unix 1_893_456_000
+  @period_end_naive ~N[2030-01-01 00:00:00]
 
-      # Simulate what the webhook does: update stripe details with canceled status
-      attrs = %{
-        trial_expires_at: nil,
-        plan_expires_at: nil,
-        status: :free
-      }
+  # The notifier webhook is configured in config/test.exs, so user registration
+  # always enqueues a "free tier" notification. To check the paid-signup
+  # notification specifically, match on its content rather than just the worker.
+  defp paid_signup_notification? do
+    [worker: Shroud.NotifierJob]
+    |> all_enqueued()
+    |> Enum.any?(&(get_in(&1.args, ["payload", "content"]) =~ "paid plan"))
+  end
 
-      Accounts.update_stripe_details!(user, attrs)
+  # Builds a Stripe-style signature header for the given payload + secret and
+  # POSTs the signed event to the webhook endpoint. Mirrors the scheme verified
+  # by Stripe.Webhook.construct_event: "t=<ts>,v1=<hmac_sha256(secret, ts.payload)>".
+  defp post_event(conn, event, opts \\ []) do
+    payload = Jason.encode!(event)
+    secret = Keyword.get(opts, :secret, @webhook_secret)
+    timestamp = System.system_time(:second)
 
-      updated_user = Repo.get!(User, user.id)
-      assert updated_user.status == :free
-      assert is_nil(updated_user.plan_expires_at)
+    signature =
+      :crypto.mac(:hmac, :sha256, secret, "#{timestamp}.#{payload}")
+      |> Base.encode16(case: :lower)
+
+    header = Keyword.get(opts, :signature, "t=#{timestamp},v1=#{signature}")
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("stripe-signature", header)
+    |> post(@webhook_path, payload)
+  end
+
+  defp subscription_event(type, object_attrs) do
+    %{
+      "object" => "event",
+      "type" => type,
+      "data" => %{"object" => Map.merge(%{"object" => "subscription"}, object_attrs)}
+    }
+  end
+
+  defp checkout_completed_event(object_attrs) do
+    %{
+      "object" => "event",
+      "type" => "checkout.session.completed",
+      "data" => %{"object" => Map.merge(%{"object" => "checkout.session"}, object_attrs)}
+    }
+  end
+
+  defp reload(%User{id: id}), do: Repo.get!(User, id)
+
+  defp paid_user(stripe_customer_id, attrs \\ %{}) do
+    user_fixture(attrs)
+    |> Accounts.update_stripe_details!(%{stripe_customer_id: stripe_customer_id})
+  end
+
+  describe "POST /api/webhooks/stripe signature verification" do
+    test "rejects an event with an invalid signature", %{conn: conn} do
+      event = subscription_event("customer.subscription.updated", %{"customer" => "cus_x"})
+
+      conn = post_event(conn, event, signature: "t=123,v1=deadbeef")
+
+      assert conn.status == 400
+    end
+
+    test "rejects an event signed with the wrong secret", %{conn: conn} do
+      event = subscription_event("customer.subscription.updated", %{"customer" => "cus_x"})
+
+      conn = post_event(conn, event, secret: "whsec_wrong")
+
+      assert conn.status == 400
+    end
+
+    test "rejects an event with a missing signature header", %{conn: conn} do
+      payload = Jason.encode!(subscription_event("customer.subscription.updated", %{}))
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(@webhook_path, payload)
+
+      assert conn.status == 400
+    end
+
+    test "accepts a correctly signed event", %{conn: conn} do
+      event = subscription_event("customer.subscription.trial_will_end", %{"customer" => "cus_x"})
+
+      conn = post_event(conn, event)
+
+      assert conn.status == 200
+    end
+  end
+
+  describe "checkout.session.completed" do
+    test "stores the Stripe customer id on the matching user", %{conn: conn} do
+      user = user_fixture()
+
+      event =
+        checkout_completed_event(%{
+          "customer_email" => user.email,
+          "customer" => "cus_new123"
+        })
+
+      conn = post_event(conn, event)
+
+      assert conn.status == 200
+      assert reload(user).stripe_customer_id == "cus_new123"
+    end
+
+    test "logs an error and still returns 200 for an unknown user", %{conn: conn} do
+      event =
+        checkout_completed_event(%{
+          "customer_email" => "nobody@example.com",
+          "customer" => "cus_unknown"
+        })
+
+      {conn, log} = with_log(fn -> post_event(conn, event) end)
+
+      assert conn.status == 200
+      assert log =~ "unknown user"
+    end
+  end
+
+  describe "customer.subscription.* -> active" do
+    test "activates the user, sets plan expiry, clears trial and notifies", %{conn: conn} do
+      user = paid_user("cus_active", %{status: :trial})
+
+      event =
+        subscription_event("customer.subscription.updated", %{
+          "customer" => "cus_active",
+          "status" => "active",
+          "current_period_end" => @period_end_unix
+        })
+
+      conn = post_event(conn, event)
+      assert conn.status == 200
+
+      updated = reload(user)
+      assert updated.status == :active
+      assert updated.plan_expires_at == @period_end_naive
+      assert is_nil(updated.trial_expires_at)
+
+      assert paid_signup_notification?()
+    end
+
+    test "also handles customer.subscription.created", %{conn: conn} do
+      user = paid_user("cus_created", %{status: :trial})
+
+      event =
+        subscription_event("customer.subscription.created", %{
+          "customer" => "cus_created",
+          "status" => "active",
+          "current_period_end" => @period_end_unix
+        })
+
+      assert post_event(conn, event).status == 200
+      assert reload(user).status == :active
+    end
+  end
+
+  describe "customer.subscription.* -> grace-period statuses" do
+    for status <- ["past_due", "incomplete"] do
+      test "leaves the user's plan unchanged for #{status}", %{conn: conn} do
+        user = paid_user("cus_grace", %{status: :active})
+
+        event =
+          subscription_event("customer.subscription.updated", %{
+            "customer" => "cus_grace",
+            "status" => unquote(status)
+          })
+
+        conn = post_event(conn, event)
+        assert conn.status == 200
+
+        updated = reload(user)
+        assert updated.status == :active
+        refute paid_signup_notification?()
+      end
+    end
+  end
+
+  describe "customer.subscription.* -> cancelling statuses" do
+    for status <- ["canceled", "unpaid", "incomplete_expired"] do
+      test "moves the user to the free tier for #{status}", %{conn: conn} do
+        user =
+          paid_user("cus_cancel", %{status: :active})
+          |> then(&Accounts.update_stripe_details!(&1, %{plan_expires_at: @period_end_naive}))
+
+        event =
+          subscription_event("customer.subscription.updated", %{
+            "customer" => "cus_cancel",
+            "status" => unquote(status)
+          })
+
+        conn = post_event(conn, event)
+        assert conn.status == 200
+
+        updated = reload(user)
+        assert updated.status == :free
+        assert is_nil(updated.plan_expires_at)
+        assert is_nil(updated.trial_expires_at)
+      end
+    end
+
+    test "customer.subscription.deleted with a canceled status frees the user", %{conn: conn} do
+      user = paid_user("cus_deleted", %{status: :active})
+
+      event =
+        subscription_event("customer.subscription.deleted", %{
+          "customer" => "cus_deleted",
+          "status" => "canceled"
+        })
+
+      assert post_event(conn, event).status == 200
+      assert reload(user).status == :free
+    end
+  end
+
+  describe "webhook edge cases" do
+    test "logs an error and returns 200 for an unknown customer", %{conn: conn} do
+      event =
+        subscription_event("customer.subscription.updated", %{
+          "customer" => "cus_does_not_exist",
+          "status" => "active",
+          "current_period_end" => @period_end_unix
+        })
+
+      {conn, log} = with_log(fn -> post_event(conn, event) end)
+
+      assert conn.status == 200
+      assert log =~ "unknown customer"
+    end
+
+    test "ignores an unhandled event type but returns 200", %{conn: conn} do
+      event =
+        subscription_event("customer.subscription.paused", %{"customer" => "cus_whatever"})
+
+      {conn, log} = with_log(fn -> post_event(conn, event) end)
+
+      assert conn.status == 200
+      assert log =~ "unhandled Stripe event"
+    end
+  end
+
+  describe "GET /checkout/billing (billing portal)" do
+    setup :register_and_log_in_user
+
+    test "redirects to billing settings when the user has no Stripe customer", %{conn: conn} do
+      # No Stripe API call is made when stripe_customer_id is nil.
+      conn = get(conn, ~p"/checkout/billing")
+
+      assert redirected_to(conn) == ~p"/settings/billing"
     end
   end
 end


### PR DESCRIPTION
Stacked on #127 (base: \`chore/upgrade-sentry\`), and sits **before** the Stripe v2→v3 upgrade (#128) so it acts as a regression guard for it.

Replaces the placeholder \`checkout_controller_test\` (which bypassed the controller and just called \`update_stripe_details!\` directly) with end-to-end tests that POST **signed** Stripe webhook payloads to \`/api/webhooks/stripe\` and assert on the resulting state.

**Coverage (17 tests):**
- **Signature verification**: invalid signature, wrong secret, missing header (all 400); valid signature (200).
- **checkout.session.completed**: stores \`stripe_customer_id\` for the matching user; logs + 200 for an unknown user.
- **subscription created/updated → active**: activates the user, sets \`plan_expires_at\`, clears the trial, enqueues the paid-signup notification.
- **grace statuses** (past_due, incomplete): plan unchanged, no paid-signup notification.
- **cancelling statuses** (canceled, unpaid, incomplete_expired) + **subscription.deleted**: user moved to free tier, expiries cleared.
- **edge cases**: unknown customer (logs + 200), unhandled event type (logs + 200).
- **billing portal** redirects to settings when the user has no Stripe customer.

**Why before the Stripe upgrade:** these run against stripity_stripe **v2** on this branch, then must stay green on **v3** in #128 — exercising the webhook signature scheme and the `event → struct` conversion the upgrade must preserve. Confirmed: after rebasing #128 on top of this branch, all 17 pass unchanged on v3.

Notifier assertions match on notification **content** (`"paid plan"`) rather than just the worker, because registration always enqueues a `"free tier"` notification (`notifier_webhook_url` is set in `config/test.exs`); this keeps the suite order-independent.

**Verified:** file (17 tests) + full suite (418 tests, 0 failures) on seeds 0 and random, format, `compile --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)