### PR TITLE
fix: deduplicate trackers in email reports

### DIFF
--- a/lib/shroud/email/tracker_remover.ex
+++ b/lib/shroud/email/tracker_remover.ex
@@ -30,6 +30,14 @@ defmodule Shroud.Email.TrackerRemover do
         other, acc -> {other, acc}
       end)
 
+    # Trackers are accumulated by prepending, so reverse to restore the order in
+    # which they appeared in the email, then deduplicate so the same tracker
+    # isn't reported multiple times.
+    removed_trackers =
+      removed_trackers
+      |> Enum.reverse()
+      |> Enum.uniq()
+
     swoosh_email = struct(email.swoosh_email, html_body: Floki.raw_html(processed_html))
 
     struct(email,

--- a/test/shroud/email/tracker_remover_test.exs
+++ b/test/shroud/email/tracker_remover_test.exs
@@ -147,6 +147,40 @@ defmodule Shroud.Email.TrackerRemoverTest do
       assert email.removed_trackers == ["SpyOnU"]
     end
 
+    test "deduplicates repeated trackers" do
+      html_body = """
+      <html>
+        <body>
+          <h1>An email</h1>
+          <img src="https://spyonu.com/track?q=123" />
+          <img src="https://spyonu.com/track?q=456" />
+          <img src="https://unknowntracker.com" width="1" height="1" />
+          <img src="https://unknowntracker.com" width="1" height="1" />
+          <p>Content</p>
+        </body>
+      </html>
+      """
+
+      expected_result = """
+      <html>
+        <body>
+          <h1>An email</h1>
+          <p>Content</p>
+        </body>
+      </html>
+      """
+
+      email =
+        html_email("sender@example.com", ["recipient@example.com"], "Subject", html_body)
+        |> :mimemail.decode()
+        |> ParsedEmail.parse("sender@example.com", "recipient@example.com")
+        |> TrackerRemover.process()
+
+      assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
+      assert Enum.empty?(Floki.find(email.parsed_html, "img"))
+      assert email.removed_trackers == ["SpyOnU", "unknowntracker.com"]
+    end
+
     test "proxies non-tracker images" do
       html_body = """
       <html>


### PR DESCRIPTION
## Summary

Fixes #20.

When the same tracker appeared multiple times in an email (e.g. a tracking pixel repeated throughout a newsletter), the email report listed it once **per occurrence**, producing a list full of duplicates.

In `TrackerRemover.process/1`, each detected tracker is prepended to an accumulator while traversing the HTML, with no deduplication. This change reverses the accumulated list to restore the order in which trackers appeared, then applies `Enum.uniq/1` so each tracker is reported only once.

```elixir
removed_trackers =
  removed_trackers
  |> Enum.reverse()
  |> Enum.uniq()
```

## Changes
- `lib/shroud/email/tracker_remover.ex` — deduplicate `removed_trackers` while preserving first-appearance order.
- `test/shroud/email/tracker_remover_test.exs` — added a `"deduplicates repeated trackers"` test covering both known trackers (same tracker matched from two URLs) and unknown pixel trackers (same host appearing twice).

## Notes
- No database migrations, feature flags, or config changes.
- `mix` isn't available in this environment, so please run `mix test test/shroud/email/tracker_remover_test.exs` before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LDbg8uhNEsGoCtWfs5tUQN)_