### PR TITLE
feat: notify users when a catch-all address fails validation

### DIFF
--- a/docs/superpowers/plans/2026-07-17-catchall-failure-original-email.md
+++ b/docs/superpowers/plans/2026-07-17-catchall-failure-original-email.md
@@ -1,0 +1,326 @@
+# Catch-all Failure Original Email Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attach the exact original non-spam message to invalid catch-all notifications while omitting spam attachments and removing the irrelevant domain-management link.
+
+**Architecture:** Keep notification delivery inside the existing `EmailHandler` Oban job, which already decodes and holds the raw SMTP message. `IncomingEmailHandler` decides whether the raw message is spam, passes either the bytes or `nil` to `UserNotifier`, and converts notifier delivery failures into `Swoosh.DeliveryError` so they escape recipient iteration and trigger the existing Oban retry behavior.
+
+**Tech Stack:** Elixir 1.18+, Phoenix, Oban, Swoosh, MJML, ExUnit
+
+## Global Constraints
+
+- Non-spam invalid catch-all messages attach the exact raw bytes as `original-message.eml` with content type `message/rfc822`.
+- Spam-marked invalid catch-all messages still send the notification but do not include an attachment.
+- The notification contains no domain-management URL, button, or equivalent text.
+- Do not add object storage, change SMTP size limits, redesign recipient job granularity, or solve duplicate delivery across retries.
+- Preserve valid catch-all creation and uniqueness-race forwarding behavior.
+
+---
+
+## File Structure
+
+- `test/shroud/email/email_handler_test.exs` — integration coverage for invalid catch-all handling, notification copy, exact attachment bytes, and spam omission.
+- `lib/shroud/email/incoming_email_handler.ex` — decides whether to attach the raw message and invokes notification delivery in the current Oban job.
+- `lib/shroud/accounts/user_notifier.ex` — creates the optional `message/rfc822` attachment and supplies attachment-status copy.
+- `lib/shroud/email_template/catchall_alias_creation_failed.mjml` — renders attachment-status copy without the domain-management button.
+
+### Task 1: Deliver Invalid Catch-all Notifications With an Optional Raw Message
+
+**Files:**
+- Modify: `test/shroud/email/email_handler_test.exs:954-984`
+- Modify: `lib/shroud/email/incoming_email_handler.ex:1-151`
+- Modify: `lib/shroud/accounts/user_notifier.ex:8-23,167-197`
+- Modify: `lib/shroud/email_template/catchall_alias_creation_failed.mjml:22-43`
+
+**Interfaces:**
+- Consumes: decoded raw RFC 822 bytes passed as `data` to `IncomingEmailHandler.handle_incoming_email/3`; `SpamHandler.spam?/1`; `Swoosh.Attachment.new/2`.
+- Produces: `UserNotifier.deliver_catchall_alias_creation_failed(user_id, address, original_message)` where `original_message` is raw binary data or `nil`; an email with zero or one original-message attachment.
+
+- [ ] **Step 1: Replace the existing enqueue-only test with a failing non-spam attachment test**
+
+In `test/shroud/email/email_handler_test.exs`, replace `"notifies the user if a catch-all address is invalid"` with:
+
+```elixir
+@tag :catchall_invalid
+test "attaches a non-spam message when a catch-all address is invalid", %{user: user} do
+  custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: true})
+  invalid_address = "invalid_address@#{custom_domain.domain}"
+
+  data =
+    text_email(
+      "sender@example.com",
+      [invalid_address],
+      "Catch-all test",
+      "Plain text content!",
+      "X-Spam-Status: No"
+    )
+
+  perform_job(EmailHandler, %{
+    from: "sender@example.com",
+    to: invalid_address,
+    data: data
+  })
+
+  assert is_nil(Aliases.get_email_alias_by_address(invalid_address))
+  refute_email_sent(subject: "Catch-all test")
+
+  assert_email_sent(fn email ->
+    assert email.to == [{"", user.email}]
+    assert email.subject == "We couldn't create a catch-all alias"
+    assert email.text_body =~ "The original message is attached for review."
+    refute email.text_body =~ "/domains/"
+    refute email.html_body =~ "/domains/"
+
+    assert [
+             %Swoosh.Attachment{
+               filename: "original-message.eml",
+               content_type: "message/rfc822",
+               type: :attachment
+             } = attachment
+           ] = email.attachments
+
+    assert Swoosh.Attachment.get_content(attachment) == data
+  end)
+end
+```
+
+- [ ] **Step 2: Add a failing spam-without-attachment integration test**
+
+Immediately after the non-spam test, add:
+
+```elixir
+@tag :catchall_invalid
+test "does not attach a spam message when a catch-all address is invalid", %{user: user} do
+  custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: true})
+  invalid_address = "spam_address@#{custom_domain.domain}"
+
+  data =
+    text_email(
+      "spammer@example.com",
+      [invalid_address],
+      "Catch-all spam test",
+      "Spam content",
+      "X-Spam-Status: Yes, score=5.1 required=5.0"
+    )
+
+  perform_job(EmailHandler, %{
+    from: "spammer@example.com",
+    to: invalid_address,
+    data: data
+  })
+
+  assert is_nil(Aliases.get_email_alias_by_address(invalid_address))
+  refute_email_sent(subject: "Catch-all spam test")
+
+  assert_email_sent(fn email ->
+    assert email.to == [{"", user.email}]
+    assert email.subject == "We couldn't create a catch-all alias"
+    assert email.attachments == []
+    assert email.text_body =~
+             "The original message was marked as spam, so it was not attached."
+
+    refute email.text_body =~ "/domains/"
+    refute email.html_body =~ "/domains/"
+  end)
+end
+```
+
+- [ ] **Step 3: Run both focused tests and verify they fail for the expected reason**
+
+Run:
+
+```bash
+mix test test/shroud/email/email_handler_test.exs --only catchall_invalid
+```
+
+Expected: both tests FAIL because the implementation only enqueues `UserNotifierJob`; no notification email or `.eml` attachment is delivered during `perform_job(EmailHandler, ...)`.
+
+- [ ] **Step 4: Extend `UserNotifier` to support an optional attachment**
+
+In `lib/shroud/accounts/user_notifier.ex`, change the private delivery helper to accept one optional attachment:
+
+```elixir
+defp deliver(recipient, subject, html_body, text_body, email_attachment \\ nil) do
+  email =
+    new()
+    |> to(recipient)
+    |> from({"Shroud.email", "noreply@#{Util.email_domain()}"})
+    |> reply_to({"Shroud.email", "contact@shroud.email"})
+    |> subject(subject)
+    |> html_body(html_body)
+    |> text_body(text_body)
+    |> maybe_attach(email_attachment)
+
+  with {:ok, _metadata} <- Mailer.deliver(email) do
+    {:ok, email}
+  end
+end
+
+defp maybe_attach(email, nil), do: email
+defp maybe_attach(email, email_attachment), do: attachment(email, email_attachment)
+```
+
+Replace `deliver_catchall_alias_creation_failed/2` with:
+
+```elixir
+def deliver_catchall_alias_creation_failed(user_id, address, original_message) do
+  user = Accounts.get_user!(user_id)
+
+  {attachment_status, email_attachment} =
+    case original_message do
+      nil ->
+        {"The original message was marked as spam, so it was not attached.", nil}
+
+      data ->
+        attachment =
+          Swoosh.Attachment.new(
+            {:data, data},
+            filename: "original-message.eml",
+            content_type: "message/rfc822"
+          )
+
+        {"The original message is attached for review.", attachment}
+    end
+
+  html_body =
+    EmailTemplate.CatchallAliasCreationFailed.render(
+      user_email: user.email,
+      address: address,
+      attachment_status: attachment_status,
+      current_year: DateTime.utc_now().year
+    )
+
+  text_body = """
+  ==============================
+
+  Hi #{user.email},
+
+  Someone sent an email to #{address} on your catch-all domain, but we couldn't
+  create an alias for it because the address is invalid. Email addresses can't
+  contain spaces or underscores.
+
+  The email was not forwarded to you. If you'd like to receive emails at this
+  address, please use a valid address (without underscores or spaces).
+
+  #{attachment_status}
+
+  ==============================
+  """
+
+  deliver(
+    user.email,
+    "We couldn't create a catch-all alias",
+    html_body,
+    text_body,
+    email_attachment
+  )
+end
+```
+
+- [ ] **Step 5: Remove the domain link and render attachment-status copy in the MJML template**
+
+In `lib/shroud/email_template/catchall_alias_creation_failed.mjml`, replace the paragraph/button tail after the invalid-address explanation with:
+
+```html
+<p>
+  The email was not forwarded to you. If you'd like to receive emails at this
+  address, please use a valid address (without underscores or spaces).
+</p>
+
+<p>{{ attachment_status }}</p>
+```
+
+Delete the `<mj-button>` for `{{ domain_url }}` entirely.
+
+- [ ] **Step 6: Deliver directly from `IncomingEmailHandler` and omit spam attachments**
+
+In `lib/shroud/email/incoming_email_handler.ex`, replace the `UserNotifierJob` alias with:
+
+```elixir
+alias Shroud.Accounts.UserNotifier
+```
+
+Change the invalid-address call to pass the raw message:
+
+```elixir
+notify_catchall_alias_creation_failed(recipient_user, recipient, data)
+```
+
+Replace the enqueueing helper with:
+
+```elixir
+@spec notify_catchall_alias_creation_failed(User.t(), String.t(), String.t()) :: :ok
+defp notify_catchall_alias_creation_failed(%User{} = user, recipient, data) do
+  original_message = if SpamHandler.spam?(data), do: nil, else: data
+
+  case UserNotifier.deliver_catchall_alias_creation_failed(
+         user.id,
+         recipient,
+         original_message
+       ) do
+    {:ok, _email} ->
+      :ok
+
+    {:error, reason} ->
+      raise Swoosh.DeliveryError, reason: reason
+  end
+end
+```
+
+Using `Swoosh.DeliveryError` is deliberate: an exception escapes both the single-recipient and `Enum.each/2` multi-recipient paths, causing Oban to retry the current `EmailHandler` job without changing unrelated handler return semantics.
+
+- [ ] **Step 7: Format the changed files**
+
+Run:
+
+```bash
+mix format \
+  lib/shroud/email/incoming_email_handler.ex \
+  lib/shroud/accounts/user_notifier.ex \
+  test/shroud/email/email_handler_test.exs
+```
+
+Expected: command exits successfully with no output.
+
+- [ ] **Step 8: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+mix test test/shroud/email/email_handler_test.exs --only catchall_invalid
+```
+
+Expected: both invalid catch-all tests PASS. The non-spam notice has the exact raw `.eml`; the spam notice has no attachment.
+
+- [ ] **Step 9: Run catch-all and notifier regressions**
+
+Run:
+
+```bash
+mix test test/shroud/email/email_handler_test.exs test/shroud/accounts/user_notifier_job_test.exs
+```
+
+Expected: all tests PASS, including valid catch-all creation, existing aliases, uniqueness handling, and existing notifier jobs.
+
+- [ ] **Step 10: Run compile and static verification**
+
+Run:
+
+```bash
+mix compile --warnings-as-errors
+mix credo --strict
+```
+
+Expected: both commands exit successfully with no new warnings or Credo issues.
+
+- [ ] **Step 11: Commit the implementation**
+
+```bash
+git add \
+  lib/shroud/email/incoming_email_handler.ex \
+  lib/shroud/accounts/user_notifier.ex \
+  lib/shroud/email_template/catchall_alias_creation_failed.mjml \
+  test/shroud/email/email_handler_test.exs
+git commit -m "feat: attach original invalid catch-all emails"
+```

--- a/docs/superpowers/specs/2026-07-17-catchall-failure-original-email-design.md
+++ b/docs/superpowers/specs/2026-07-17-catchall-failure-original-email-design.md
@@ -1,0 +1,67 @@
+# Catch-all Alias Failure Original Email Design
+
+## Goal
+
+When an incoming message targets an invalid address on a catch-all domain, notify the domain owner and let them recover legitimate mail without forwarding content that SpamAssassin marked as spam.
+
+## Behavior
+
+- Alias creation still fails for addresses rejected by `EmailAlias.changeset/2`, such as local parts containing spaces or underscores.
+- The incoming message is not forwarded and no alias is created.
+- The system sends the domain owner the existing “We couldn't create a catch-all alias” notification.
+- If `SpamHandler.spam?/1` returns `false`, the notification includes the exact raw incoming message as an attachment:
+  - filename: `original-message.eml`
+  - content type: `message/rfc822`
+- If `SpamHandler.spam?/1` returns `true`, the notification has no attachment and explains that the original was omitted because it was marked as spam.
+- The notification contains no “Manage domain” button, URL, or equivalent text. The domain page does not help recover an invalid incoming address.
+
+## Architecture and Data Flow
+
+The existing `EmailHandler` Oban job already contains the Base64-encoded SMTP message. It decodes that value before calling `IncomingEmailHandler`, so attachment delivery should use the decoded raw message directly rather than copying it into a second Oban job.
+
+The invalid catch-all flow is:
+
+1. `EmailHandler` decodes the raw SMTP message.
+2. `IncomingEmailHandler` attempts catch-all alias creation.
+3. Alias validation fails with a non-uniqueness changeset error.
+4. `IncomingEmailHandler` calls `SpamHandler.spam?/1` on the raw message.
+5. `UserNotifier` builds and delivers the notification synchronously within the current `EmailHandler` job.
+6. For non-spam, `UserNotifier` adds a `Swoosh.Attachment` created from `{:data, raw_message}`. For spam, it adds no attachment.
+
+The existing uniqueness-race handling remains unchanged: a uniqueness constraint error forwards the message through the alias that another concurrent job created.
+
+## Delivery Failure Handling
+
+If notification delivery returns `{:error, reason}`, the invalid catch-all path propagates that error through `EmailHandler.perform/1`. Oban marks the existing job retryable and retries it according to `EmailHandler`'s current worker configuration. Other incoming-email branches retain their current return behavior.
+
+This design does not attempt to solve recipient-level idempotency for jobs containing multiple SMTP envelope recipients. Duplicate processing after a later-recipient failure is a pre-existing job-granularity concern and is outside this change.
+
+## Notification Copy
+
+The HTML and text bodies retain the explanation that the requested alias address was invalid.
+
+They add one status-specific sentence:
+
+- Non-spam: “The original message is attached for review.”
+- Spam: “The original message was marked as spam, so it was not attached.”
+
+The domain-management link and button are removed from both variants.
+
+## Testing
+
+Tests will verify:
+
+1. A non-spam message sent to an invalid catch-all address creates no alias and is not forwarded.
+2. The resulting notification has the expected recipient and subject.
+3. The notification has one `message/rfc822` attachment named `original-message.eml` whose bytes exactly equal the raw incoming message.
+4. A spam-marked invalid catch-all message still sends the notification but has no attachment.
+5. The HTML and text notification bodies contain the correct attachment-status copy and no domain-management link.
+6. Existing valid catch-all creation and uniqueness-race behavior remain unchanged.
+
+## Out of Scope
+
+- Storing raw messages in S3 or another temporary object store.
+- Changing SMTP message-size limits.
+- Redesigning `EmailHandler` into one job per SMTP recipient.
+- Solving duplicate delivery across Oban retries.
+- Changing SpamAssassin thresholds or header trust.

--- a/lib/shroud/accounts/user_notifier.ex
+++ b/lib/shroud/accounts/user_notifier.ex
@@ -164,6 +164,39 @@ defmodule Shroud.Accounts.UserNotifier do
     deliver(user.email, "We blocked a spam email", html_body, text_body)
   end
 
+  def deliver_catchall_alias_creation_failed(user_id, address) do
+    user = Accounts.get_user!(user_id)
+    {_local, domain} = Util.extract_email_parts(address)
+    domain_url = url(~p"/domains/#{domain}")
+
+    html_body =
+      EmailTemplate.CatchallAliasCreationFailed.render(
+        user_email: user.email,
+        address: address,
+        domain_url: domain_url,
+        current_year: DateTime.utc_now().year
+      )
+
+    text_body = """
+    ==============================
+
+    Hi #{user.email},
+
+    Someone sent an email to #{address} on your catch-all domain, but we couldn't
+    create an alias for it because the address is invalid. Email addresses can't
+    contain spaces or underscores.
+
+    The email was not forwarded to you. If you'd like to receive emails at this
+    address, please use a valid address (without underscores or spaces).
+
+    You can manage your domain here: #{domain_url}
+
+    ==============================
+    """
+
+    deliver(user.email, "We couldn't create a catch-all alias", html_body, text_body)
+  end
+
   def deliver_domain_verified(custom_domain_id) do
     custom_domain = Repo.get(CustomDomain, custom_domain_id) |> Repo.preload(:user)
     user = custom_domain.user

--- a/lib/shroud/accounts/user_notifier.ex
+++ b/lib/shroud/accounts/user_notifier.ex
@@ -6,7 +6,7 @@ defmodule Shroud.Accounts.UserNotifier do
   use ShroudWeb, :verified_routes
 
   # Delivers the email using the application mailer.
-  defp deliver(recipient, subject, html_body, text_body) do
+  defp deliver(recipient, subject, html_body, text_body, email_attachment \\ nil) do
     email =
       new()
       |> to(recipient)
@@ -15,11 +15,15 @@ defmodule Shroud.Accounts.UserNotifier do
       |> subject(subject)
       |> html_body(html_body)
       |> text_body(text_body)
+      |> maybe_attach(email_attachment)
 
     with {:ok, _metadata} <- Mailer.deliver(email) do
       {:ok, email}
     end
   end
+
+  defp maybe_attach(email, nil), do: email
+  defp maybe_attach(email, email_attachment), do: attachment(email, email_attachment)
 
   @doc """
   Deliver instructions to confirm account.
@@ -164,16 +168,30 @@ defmodule Shroud.Accounts.UserNotifier do
     deliver(user.email, "We blocked a spam email", html_body, text_body)
   end
 
-  def deliver_catchall_alias_creation_failed(user_id, address) do
+  def deliver_catchall_alias_creation_failed(user_id, address, original_message) do
     user = Accounts.get_user!(user_id)
-    {_local, domain} = Util.extract_email_parts(address)
-    domain_url = url(~p"/domains/#{domain}")
+
+    {attachment_status, email_attachment} =
+      case original_message do
+        nil ->
+          {"The original message was marked as spam, so it was not attached.", nil}
+
+        data ->
+          attachment =
+            Swoosh.Attachment.new(
+              {:data, data},
+              filename: "original-message.eml",
+              content_type: "message/rfc822"
+            )
+
+          {"The original message is attached for review.", attachment}
+      end
 
     html_body =
       EmailTemplate.CatchallAliasCreationFailed.render(
         user_email: user.email,
         address: address,
-        domain_url: domain_url,
+        attachment_status: attachment_status,
         current_year: DateTime.utc_now().year
       )
 
@@ -189,12 +207,18 @@ defmodule Shroud.Accounts.UserNotifier do
     The email was not forwarded to you. If you'd like to receive emails at this
     address, please use a valid address (without underscores or spaces).
 
-    You can manage your domain here: #{domain_url}
+    #{attachment_status}
 
     ==============================
     """
 
-    deliver(user.email, "We couldn't create a catch-all alias", html_body, text_body)
+    deliver(
+      user.email,
+      "We couldn't create a catch-all alias",
+      html_body,
+      text_body,
+      email_attachment
+    )
   end
 
   def deliver_domain_verified(custom_domain_id) do

--- a/lib/shroud/email/incoming_email_handler.ex
+++ b/lib/shroud/email/incoming_email_handler.ex
@@ -111,13 +111,22 @@ defmodule Shroud.Email.IncomingEmailHandler do
 
         forward_incoming_email(recipient_user, sender, recipient, data)
 
-      {:error, %Ecto.Changeset{}} ->
-        maybe_log(
-          recipient_user,
-          "Could not create catch-all alias #{recipient} (from #{sender}) as the address is invalid. Notifying #{recipient_user.email}."
-        )
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if uniqueness_constraint_error?(changeset, :address) do
+          maybe_log(
+            recipient_user,
+            "Alias #{recipient} already exists (likely created by concurrent catch-all). Forwarding email from #{sender} to #{recipient_user.email}"
+          )
 
-        notify_catchall_alias_creation_failed(recipient_user, recipient)
+          forward_incoming_email(recipient_user, sender, recipient, data)
+        else
+          maybe_log(
+            recipient_user,
+            "Could not create catch-all alias #{recipient} (from #{sender}) as the address is invalid. Notifying #{recipient_user.email}."
+          )
+
+          notify_catchall_alias_creation_failed(recipient_user, recipient)
+        end
 
       {:error, reason} ->
         maybe_log(
@@ -245,5 +254,13 @@ defmodule Shroud.Email.IncomingEmailHandler do
             email |> Map.put(:reply_to, {reply_to_reply_address, reply_to_reply_address})
           end
         end).()
+  end
+
+  @spec uniqueness_constraint_error?(Ecto.Changeset.t(), atom()) :: boolean()
+  defp uniqueness_constraint_error?(changeset, field) do
+    Enum.any?(changeset.errors, fn
+      {^field, {_message, [constraint: :unique, constraint_name: _name]}} -> true
+      _ -> false
+    end)
   end
 end

--- a/lib/shroud/email/incoming_email_handler.ex
+++ b/lib/shroud/email/incoming_email_handler.ex
@@ -1,6 +1,7 @@
 defmodule Shroud.Email.IncomingEmailHandler do
   alias Shroud.Accounts
   alias Shroud.Accounts.User
+  alias Shroud.Accounts.UserNotifierJob
   alias Shroud.Aliases
   alias Shroud.Domain
   alias Shroud.Email
@@ -97,19 +98,47 @@ defmodule Shroud.Email.IncomingEmailHandler do
        ) do
     recipient_user = custom_domain.user
 
-    {:ok, _email_alias} =
-      Aliases.create_email_alias(%{
-        user_id: recipient_user.id,
-        address: recipient,
-        notes: "Created by catch-all"
-      })
+    case Aliases.create_email_alias(%{
+           user_id: recipient_user.id,
+           address: recipient,
+           notes: "Created by catch-all"
+         }) do
+      {:ok, _email_alias} ->
+        maybe_log(
+          recipient_user,
+          "Created alias #{recipient} via catch-all. Forwarding incoming email from #{sender} to #{recipient_user.email}"
+        )
 
-    maybe_log(
-      recipient_user,
-      "Created alias #{recipient} via catch-all. Forwarding incoming email from #{sender} to #{recipient_user.email}"
-    )
+        forward_incoming_email(recipient_user, sender, recipient, data)
 
-    forward_incoming_email(recipient_user, sender, recipient, data)
+      {:error, %Ecto.Changeset{}} ->
+        maybe_log(
+          recipient_user,
+          "Could not create catch-all alias #{recipient} (from #{sender}) as the address is invalid. Notifying #{recipient_user.email}."
+        )
+
+        notify_catchall_alias_creation_failed(recipient_user, recipient)
+
+      {:error, reason} ->
+        maybe_log(
+          recipient_user,
+          "Could not create catch-all alias #{recipient} (from #{sender}): #{inspect(reason)}"
+        )
+
+        {:error, reason}
+    end
+  end
+
+  @spec notify_catchall_alias_creation_failed(User.t(), String.t()) :: :ok
+  defp notify_catchall_alias_creation_failed(%User{} = user, recipient) do
+    %{
+      email_function: :deliver_catchall_alias_creation_failed,
+      email_args: [user.id, recipient]
+    }
+    |> UserNotifierJob.new()
+    |> Oban.insert!()
+
+    :ok
   end
 
   @spec forward_incoming_email(User.t(), String.t(), String.t(), String.t()) ::

--- a/lib/shroud/email/incoming_email_handler.ex
+++ b/lib/shroud/email/incoming_email_handler.ex
@@ -1,7 +1,7 @@
 defmodule Shroud.Email.IncomingEmailHandler do
   alias Shroud.Accounts
   alias Shroud.Accounts.User
-  alias Shroud.Accounts.UserNotifierJob
+  alias Shroud.Accounts.UserNotifier
   alias Shroud.Aliases
   alias Shroud.Domain
   alias Shroud.Email
@@ -125,7 +125,7 @@ defmodule Shroud.Email.IncomingEmailHandler do
             "Could not create catch-all alias #{recipient} (from #{sender}) as the address is invalid. Notifying #{recipient_user.email}."
           )
 
-          notify_catchall_alias_creation_failed(recipient_user, recipient)
+          notify_catchall_alias_creation_failed(recipient_user, recipient, data)
         end
 
       {:error, reason} ->
@@ -138,16 +138,21 @@ defmodule Shroud.Email.IncomingEmailHandler do
     end
   end
 
-  @spec notify_catchall_alias_creation_failed(User.t(), String.t()) :: :ok
-  defp notify_catchall_alias_creation_failed(%User{} = user, recipient) do
-    %{
-      email_function: :deliver_catchall_alias_creation_failed,
-      email_args: [user.id, recipient]
-    }
-    |> UserNotifierJob.new()
-    |> Oban.insert!()
+  @spec notify_catchall_alias_creation_failed(User.t(), String.t(), String.t()) :: :ok
+  defp notify_catchall_alias_creation_failed(%User{} = user, recipient, data) do
+    original_message = if SpamHandler.spam?(data), do: nil, else: data
 
-    :ok
+    case UserNotifier.deliver_catchall_alias_creation_failed(
+           user.id,
+           recipient,
+           original_message
+         ) do
+      {:ok, _email} ->
+        :ok
+
+      {:error, reason} ->
+        raise Swoosh.DeliveryError, reason: reason
+    end
   end
 
   @spec forward_incoming_email(User.t(), String.t(), String.t(), String.t()) ::

--- a/lib/shroud/email_template/catchall_alias_creation_failed.ex
+++ b/lib/shroud/email_template/catchall_alias_creation_failed.ex
@@ -1,0 +1,10 @@
+defmodule Shroud.EmailTemplate.CatchallAliasCreationFailed do
+  @template_path Path.join([__DIR__, "catchall_alias_creation_failed.mjml"])
+  @external_resource @template_path
+
+  require EEx
+  alias Shroud.Mailer
+
+  rendered_mjml = Mailer.generate_template(@template_path)
+  EEx.function_from_string(:def, :render, rendered_mjml, [:assigns])
+end

--- a/lib/shroud/email_template/catchall_alias_creation_failed.mjml
+++ b/lib/shroud/email_template/catchall_alias_creation_failed.mjml
@@ -1,0 +1,55 @@
+<mjml>
+  <mj-head>
+    <mj-font name="Inter" href="https://app.shroud.email/fonts/inter/inter.css" />
+    <mj-attributes>
+      <mj-all font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji" ico-font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji" />
+    </mj-attributes>
+    <mj-style> .link-nostyle { color: inherit; text-decoration: none } </mj-style>
+  </mj-head>
+  <mj-body>
+    <mj-section full-width="full-width" background-color="#1f2937" padding-top="10px" padding-bottom="10px">
+      <mj-column>
+        <mj-social>
+          <mj-social-element font-size="20px" color="#fff" name="Shroud.email" href="https://shroud.email" src="https://app.shroud.email/images/logo.png">
+            Shroud.email
+          </mj-social-element>
+        </mj-social>
+      </mj-column>
+    </mj-section>
+    <mj-section full-width="full-width" padding-top="40px" padding-bottom="40px" background-color="white">
+      <mj-column>
+        <mj-text align="center" color="#111827" font-size="20px">
+          <h1>We couldn't create a catch-all alias</h1>
+        </mj-text>
+        <mj-text color="#111827" font-size="16px">
+          <p>Hi {{ user_email }},</p>
+
+          <p>
+            Someone sent an email to <strong>{{ address }}</strong> on your catch-all
+            domain, but we couldn't create an alias for it because the address is invalid.
+            Email addresses can't contain spaces or underscores.
+          </p>
+
+          <p>
+            The email was not forwarded to you. If you'd like to receive emails at this
+            address, please use a valid address (without underscores or spaces).
+          </p>
+
+          <mj-button align="center" href="{{ domain_url }}" font-size="16px" background-color="#4f46e5" border-radius="7px">Manage domain</mj-button>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section full-width="full-width" padding-top="20px" background-color="#1f2937">
+      <mj-column>
+        <mj-text font-size="12px" color="lightgray">
+          <a class="link-nostyle" href="https://shroud.email">Shroud.email</a>
+        </mj-text>
+      </mj-column>
+      <mj-column>
+        <mj-text font-size="12px" color="lightgray" align="right">
+          {{ current_year }}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/lib/shroud/email_template/catchall_alias_creation_failed.mjml
+++ b/lib/shroud/email_template/catchall_alias_creation_failed.mjml
@@ -35,7 +35,7 @@
             address, please use a valid address (without underscores or spaces).
           </p>
 
-          <mj-button align="center" href="{{ domain_url }}" font-size="16px" background-color="#4f46e5" border-radius="7px">Manage domain</mj-button>
+          <p>{{ attachment_status }}</p>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -951,7 +951,8 @@ defmodule Shroud.Email.EmailHandlerTest do
       assert metric.forwarded == 2
     end
 
-    test "notifies the user if a catch-all address is invalid", %{user: user} do
+    @tag :catchall_invalid
+    test "attaches a non-spam message when a catch-all address is invalid", %{user: user} do
       custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: true})
       invalid_address = "invalid_address@#{custom_domain.domain}"
 
@@ -960,7 +961,8 @@ defmodule Shroud.Email.EmailHandlerTest do
           "sender@example.com",
           [invalid_address],
           "Catch-all test",
-          "Plain text content!"
+          "Plain text content!",
+          "X-Spam-Status: No"
         )
 
       perform_job(EmailHandler, %{
@@ -969,18 +971,64 @@ defmodule Shroud.Email.EmailHandlerTest do
         data: data
       })
 
-      # No alias is created and the email is not forwarded
       assert is_nil(Aliases.get_email_alias_by_address(invalid_address))
-      assert_no_email_sent()
+      refute_email_sent(subject: "Catch-all test")
 
-      # But the user is notified that we couldn't create the alias
-      assert_enqueued(
-        worker: Shroud.Accounts.UserNotifierJob,
-        args: %{
-          email_function: :deliver_catchall_alias_creation_failed,
-          email_args: [user.id, invalid_address]
-        }
-      )
+      assert_email_sent(fn email ->
+        assert email.to == [{"", user.email}]
+        assert email.subject == "We couldn't create a catch-all alias"
+        assert email.text_body =~ "The original message is attached for review."
+        refute email.text_body =~ "/domains/"
+        refute email.html_body =~ "/domains/"
+
+        assert [
+                 %Swoosh.Attachment{
+                   filename: "original-message.eml",
+                   content_type: "message/rfc822",
+                   type: :attachment
+                 } = attachment
+               ] = email.attachments
+
+        assert Swoosh.Attachment.get_content(attachment) == data
+        true
+      end)
+    end
+
+    @tag :catchall_invalid
+    test "does not attach a spam message when a catch-all address is invalid", %{user: user} do
+      custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: true})
+      invalid_address = "spam_address@#{custom_domain.domain}"
+
+      data =
+        text_email(
+          "spammer@example.com",
+          [invalid_address],
+          "Catch-all spam test",
+          "Spam content",
+          "X-Spam-Status: Yes, score=5.1 required=5.0"
+        )
+
+      perform_job(EmailHandler, %{
+        from: "spammer@example.com",
+        to: invalid_address,
+        data: data
+      })
+
+      assert is_nil(Aliases.get_email_alias_by_address(invalid_address))
+      refute_email_sent(subject: "Catch-all spam test")
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"", user.email}]
+        assert email.subject == "We couldn't create a catch-all alias"
+        assert email.attachments == []
+
+        assert email.text_body =~
+                 "The original message was marked as spam, so it was not attached."
+
+        refute email.text_body =~ "/domains/"
+        refute email.html_body =~ "/domains/"
+        true
+      end)
     end
 
     test "does not create an alias if catch-all is disabled", %{user: user} do

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -951,6 +951,38 @@ defmodule Shroud.Email.EmailHandlerTest do
       assert metric.forwarded == 2
     end
 
+    test "notifies the user if a catch-all address is invalid", %{user: user} do
+      custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: true})
+      invalid_address = "invalid_address@#{custom_domain.domain}"
+
+      data =
+        text_email(
+          "sender@example.com",
+          [invalid_address],
+          "Catch-all test",
+          "Plain text content!"
+        )
+
+      perform_job(EmailHandler, %{
+        from: "sender@example.com",
+        to: invalid_address,
+        data: data
+      })
+
+      # No alias is created and the email is not forwarded
+      assert is_nil(Aliases.get_email_alias_by_address(invalid_address))
+      assert_no_email_sent()
+
+      # But the user is notified that we couldn't create the alias
+      assert_enqueued(
+        worker: Shroud.Accounts.UserNotifierJob,
+        args: %{
+          email_function: :deliver_catchall_alias_creation_failed,
+          email_args: [user.id, invalid_address]
+        }
+      )
+    end
+
     test "does not create an alias if catch-all is disabled", %{user: user} do
       custom_domain = custom_domain_fixture(%{user_id: user.id, catchall_enabled: false})
 


### PR DESCRIPTION
## Summary

Closes #82.

When catch-all is enabled and an email arrives at an **invalid** address (e.g. `my_address@customdomain.com` — alias addresses can't contain underscores or spaces per the validation regex), `create_catchall_address/4` previously did a strict `{:ok, _} = Aliases.create_email_alias(...)` match, which **crashed** on the `{:error, changeset}` return. We now handle this gracefully and let the user know.

## Changes

- **`lib/shroud/email/incoming_email_handler.ex`** — `create_catchall_address/4` now uses a `case`:
  - `{:ok, _}` → forward as before
  - `{:error, %Ecto.Changeset{}}` (invalid address) → log and enqueue a notification email to the user
  - `{:error, reason}` (e.g. limit reached / inactive user) → log instead of crashing
  - New private `notify_catchall_alias_creation_failed/2` enqueues a `UserNotifierJob` (same pattern the spam handler uses).
- **`lib/shroud/accounts/user_notifier.ex`** — Added `deliver_catchall_alias_creation_failed/2`, rendering the new template with HTML + text bodies and a link to the domain management page.
- **New email template** — `catchall_alias_creation_failed.{mjml,ex}`, mirroring the existing notification templates.
- **`test/shroud/email/email_handler_test.exs`** — Added a test asserting that an invalid catch-all address creates no alias, forwards no email, and enqueues the notification job.

## Notes

- No database migrations, feature flags, or config toggles.
- ⚠️ I was unable to run `mix compile` / `mix test` in the execution environment (Elixir/mix not installed), so the code is verified by inspection against existing patterns rather than a local test run. Please confirm CI is green.

https://claude.ai/code/session_014bZA1sVcDvX3L2bSNgdSYf

---
_Generated by [Claude Code](https://claude.ai/code/session_014bZA1sVcDvX3L2bSNgdSYf)_