### PR TITLE
chore: upgrade to Elixir 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          elixir-version: "1.19.5"
+          elixir-version: "1.20.0"
           otp-version: "28"
       - name: Restore dependencies cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/sobelow.yml
+++ b/.github/workflows/sobelow.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          elixir-version: "1.19.5"
+          elixir-version: "1.20.0"
           otp-version: "28"
       - name: Restore dependencies cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 ARG MIX_ENV="prod"
 
-FROM hexpm/elixir:1.19.5-erlang-28.5.0.1-debian-bookworm-20260518-slim AS build
+FROM hexpm/elixir:1.20.0-erlang-28.5.0.1-debian-bookworm-20260518-slim AS build
 
 # install build dependencies
 RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -53,7 +53,7 @@ RUN mix release
 
 # start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities
-FROM hexpm/elixir:1.19.5-erlang-28.5.0.1-debian-bookworm-20260518-slim AS app
+FROM hexpm/elixir:1.20.0-erlang-28.5.0.1-debian-bookworm-20260518-slim AS app
 RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \

--- a/lib/shroud/application.ex
+++ b/lib/shroud/application.ex
@@ -32,7 +32,7 @@ defmodule Shroud.Application do
         ])
       end
 
-    Logger.add_backend(Sentry.LoggerBackend)
+    :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{})
 
     :telemetry.attach(
       "oban-errors",

--- a/lib/shroud/email/email_handler.ex
+++ b/lib/shroud/email/email_handler.ex
@@ -1,7 +1,6 @@
 defmodule Shroud.Email.EmailHandler do
   use Oban.Worker, queue: :outgoing_email, max_attempts: 100
 
-  require Logger
   alias Shroud.Accounts
 
   alias Shroud.Email.{

--- a/lib/shroud/email/outgoing_email_handler.ex
+++ b/lib/shroud/email/outgoing_email_handler.ex
@@ -91,8 +91,6 @@ defmodule Shroud.Email.OutgoingEmailHandler do
     |> Map.put(:reply_to, nil)
   end
 
-  defp sender_owns_alias?(nil, _reply_address), do: false
-
   defp sender_owns_alias?(user, reply_address) do
     {_recipient_address, email_alias} = ReplyAddress.from_reply_address(reply_address)
     email_alias = Aliases.get_email_alias_by_address(email_alias)

--- a/lib/shroud_web.ex
+++ b/lib/shroud_web.ex
@@ -52,7 +52,8 @@ defmodule ShroudWeb do
     quote do
       @opts Keyword.merge(
               [
-                layout: {ShroudWeb.Layouts, :live}
+                layout: {ShroudWeb.Layouts, :live},
+                global_prefixes: ~w(x-)
               ],
               unquote(opts)
             )

--- a/lib/shroud_web/components/layouts/navbar.html.heex
+++ b/lib/shroud_web/components/layouts/navbar.html.heex
@@ -131,13 +131,11 @@
           </div>
           <div class="ml-3">
             <div class="text-base font-medium leading-none text-white"><%= @current_user.email %></div>
-            <%= if @current_user do %>
-              <%= if @current_user.status == :free do %>
-                <div class="text-gray-400 mr-2">
-                  Free plan.
-                  <.link href={~p"/settings/billing"} class="underline hover:text-gray-500">Upgrade</.link>
-                </div>
-              <% end %>
+            <%= if @current_user.status == :free do %>
+              <div class="text-gray-400 mr-2">
+                Free plan.
+                <.link href={~p"/settings/billing"} class="underline hover:text-gray-500">Upgrade</.link>
+              </div>
             <% end %>
           </div>
         </div>

--- a/lib/shroud_web/live/email_alias_live/show.ex
+++ b/lib/shroud_web/live/email_alias_live/show.ex
@@ -1,7 +1,6 @@
 defmodule ShroudWeb.EmailAliasLive.Show do
   import Canada, only: [can?: 2]
   use ShroudWeb, :live_view
-  use Phoenix.Component, global_prefixes: ~w(x-)
   alias Shroud.{Accounts, Aliases}
   alias Shroud.Email.ReplyAddress
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-elixir = "1.19"
+elixir = "1.20"
 erlang = "28"
 node = "24.8.0"
 pinact = "4.1.0"

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -774,9 +774,9 @@ defmodule Shroud.Email.EmailHandlerTest do
       assert_enqueued(worker: Shroud.S3.S3UploadJob)
     end
 
-    test "discards outgoing email from free users", %{email_alias: email_alias} do
+    test "discards outgoing email from free users" do
       free_user = user_fixture(%{status: :free, email: "freeuser@example.com"})
-      free_alias = alias_fixture(%{user_id: free_user.id, address: "freealias@email.shroud.test"})
+      _free_alias = alias_fixture(%{user_id: free_user.id, address: "freealias@email.shroud.test"})
 
       data =
         text_email(

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -776,7 +776,9 @@ defmodule Shroud.Email.EmailHandlerTest do
 
     test "discards outgoing email from free users" do
       free_user = user_fixture(%{status: :free, email: "freeuser@example.com"})
-      _free_alias = alias_fixture(%{user_id: free_user.id, address: "freealias@email.shroud.test"})
+
+      _free_alias =
+        alias_fixture(%{user_id: free_user.id, address: "freealias@email.shroud.test"})
 
       data =
         text_email(


### PR DESCRIPTION
Upgrades the project from Elixir 1.19 to [1.20](https://elixir-lang.org/blog/2026/06/03/elixir-v1-20-0-released/), and fixes the issues surfaced by 1.20's new type-system inference under `mix compile --warnings-as-errors`.

