### PR TITLE
fix: stop enqueuing DnsChecker jobs inside a streaming transaction

### DIFF
--- a/lib/shroud/scheduler.ex
+++ b/lib/shroud/scheduler.ex
@@ -13,12 +13,9 @@ defmodule Shroud.Scheduler do
   end
 
   def verify_custom_domains() do
-    Repo.transaction(fn ->
-      CustomDomain
-      |> Repo.stream(max_rows: 100)
-      |> Stream.each(&schedule_dns_checker_job/1)
-      |> Stream.run()
-    end)
+    CustomDomain
+    |> Repo.all()
+    |> Enum.each(&schedule_dns_checker_job/1)
   end
 
   def delete_spam_emails() do


### PR DESCRIPTION
## Problem

Production hit `RuntimeError: :rollback` from `Oban.insert!` inside `Scheduler.verify_custom_domains/0`.

I am not sure of the root cause, so this is an experimental change. The theory is:

> `verify_custom_domains/0` streamed `CustomDomain` rows inside a `Repo.transaction` — required by `Repo.stream` — and called `Oban.insert!` per row. `DnsChecker` is a **unique** worker, so for each insert Oban opens its own nested transaction (`insert_job` → `Repo.transaction`). Nesting those inside the long-lived streaming-cursor transaction is fragile: if a concurrent write to `oban_jobs` deadlocks or hits a serialization failure during the scan, the **outer** transaction is aborted, and every remaining `Oban.insert!` then returns `{:error, :rollback}` → `RuntimeError: :rollback`, killing the whole hourly run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

