### PR TITLE
fix: strip double quotes from parsed email addresses

### DIFF
--- a/lib/shroud/email/parsed_email.ex
+++ b/lib/shroud/email/parsed_email.ex
@@ -211,27 +211,32 @@ defmodule Shroud.Email.ParsedEmail do
   end
 
   # Sanitizes malformed email addresses by:
-  # 1. Removing spaces from the local part
+  # 1. Removing spaces and double quotes from the local part
   # 2. Stripping invalid bracket notation from domains (e.g., [domain] -> domain)
-  # This handles (likely spam) emails that have invalid addresses like "foo bar@example.com"
+  # This handles emails with invalid addresses like "foo bar@example.com"
   # or "user@[domain]" which would otherwise cause gen_smtp/mimemail to crash during encoding.
+  # Double quotes are particularly important to strip: a header like
+  # `To: "Subscriber" foo@example.com` (a quoted display name with no angle brackets) parses
+  # into an address of `"Subscriber"foo@example.com`. When that address is later placed inside
+  # `<...>` for an outgoing From/Reply-To header, mimemail crashes with
+  # {:error, {1, :smtp_rfc5322_scan, {:illegal, ~c"\"\""}}}.
   # It's not great that we're modifying the email address, but it's better than crashing.
   defp sanitize_email_address(address) do
     case String.split(address, "@", parts: 2) do
       [local_part, domain] ->
-        sanitized_local = String.replace(local_part, ~r/\s+/, "")
-        sanitized_domain = sanitize_domain(domain)
+        sanitized_local = String.replace(local_part, ~r/[\s"]+/, "")
+        sanitized_domain = domain |> sanitize_domain() |> String.replace(~r/["]+/, "")
         "#{sanitized_local}@#{sanitized_domain}"
 
       _ ->
-        # No @ sign found, just remove spaces
-        String.replace(address, ~r/\s+/, "")
+        # No @ sign found, just remove spaces and quotes
+        String.replace(address, ~r/[\s"]+/, "")
     end
   end
 
   # Sanitizes the domain part of an email address.
   # RFC 5321 allows IP address literals in brackets like [192.168.1.1] or [IPv6:...],
-  # but some spam emails use invalid bracket notation like [domain].
+  # but some emails use invalid bracket notation like [domain].
   # This strips brackets from invalid bracket notation while preserving valid IP literals.
   defp sanitize_domain(domain) do
     case Regex.run(~r/^\[(.+)\]$/, domain) do

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -368,6 +368,67 @@ defmodule Shroud.Email.EmailHandlerTest do
       end)
     end
 
+    test "handles a sender address with a quoted name but no angle brackets", %{
+      user: user,
+      email_alias: email_alias
+    } do
+      # Some emails have a malformed "From" header with a quoted display name
+      # but no angle brackets, e.g. `From: "Sales Team" promo@example.com`. This parses
+      # into an address of `"Sales Team"promo@example.com` (quotes retained). The address
+      # then feeds the outgoing reply address, and mimemail crashes while encoding the
+      # `From` header with {:error, {1, :smtp_rfc5322_scan, {:illegal, ~c"\"\""}}}.
+      data =
+        text_email(
+          ~s("Sales Team" promo@example.com),
+          [{"Recipient", email_alias.address}],
+          "Text only",
+          "Plain text content!"
+        )
+
+      args = %{from: "promo@example.com", to: email_alias.address, data: data}
+      perform_job(EmailHandler, args)
+
+      assert_email_sent(fn email ->
+        {_name, from_address} = email.from
+        # The outgoing address must not contain double quotes, otherwise encoding fails.
+        refute from_address =~ ~s(")
+
+        # Faithfully reproduce the production crash: encoding the forwarded email
+        # for SMTP delivery must not raise.
+        assert is_binary(Swoosh.Adapters.SMTP.Helpers.body(email, []))
+      end)
+    end
+
+    test "handles a recipient address with a quoted name but no angle brackets", %{
+      user: user,
+      email_alias: email_alias
+    } do
+      # A malformed "To" header with a quoted display name but no angle brackets, e.g.
+      # `To: "Subscriber" alias@email.shroud.test`, parses into an address (and display
+      # name) containing double quotes. Those quotes must be stripped so the forwarded
+      # email can be encoded for delivery.
+      malformed_recipient = ~s("Subscriber" #{email_alias.address})
+
+      data =
+        text_email(
+          {"Sender", "sender@example.com"},
+          [malformed_recipient],
+          "Text only",
+          "Plain text content!"
+        )
+
+      args = %{from: "sender@example.com", to: email_alias.address, data: data}
+      perform_job(EmailHandler, args)
+
+      assert_email_sent(fn email ->
+        {recipient_name, recipient_address} = hd(email.to)
+        assert recipient_address == user.email
+        refute recipient_name =~ ~s(")
+
+        assert is_binary(Swoosh.Adapters.SMTP.Helpers.body(email, []))
+      end)
+    end
+
     test "handles text/html email", %{user: user, email_alias: email_alias} do
       data = html_email("sender@example.com", [email_alias.address], "HTML only", @html_content)
       args = %{from: "sender@example.com", to: email_alias.address, data: data}

--- a/test/shroud/email/parsed_email_test.exs
+++ b/test/shroud/email/parsed_email_test.exs
@@ -206,6 +206,27 @@ defmodule Shroud.Email.ParsedEmailTest do
       assert reply_to_address == "jane@invalid"
     end
 
+    test "strips quotes from addresses that have no @ sign" do
+      # A "From" header with a quoted value and no @ sign (e.g. `From: "No Email"`)
+      # parses into an address with no @. The quotes must still be stripped so the
+      # value can be encoded into an outgoing header without crashing mimemail.
+      email_raw =
+        text_email(
+          ~s("No Email"),
+          ["info@example.com"],
+          "Test email with quoted address and no @ sign",
+          "Test body"
+        )
+
+      mimemail_email = :mimemail.decode(email_raw)
+
+      %{swoosh_email: email} =
+        ParsedEmail.parse(mimemail_email, "sender@example.com", "alias@email.shroud.test")
+
+      {_from_name, from_address} = email.from
+      assert from_address == "NoEmail"
+    end
+
     test "preserves valid IP address bracket notation in domains" do
       # Valid IP address literals in brackets should be preserved
       email_raw =


### PR DESCRIPTION
## Problem

Forwarding certain incoming emails crashed with:

```
** (MatchError) no match of right hand side value: {:error, {1, :smtp_rfc5322_scan, {:illegal, ~c"\"\""}}}
    (gen_smtp 1.3.0) mimemail.erl:1184: :mimemail.encode_header_value/2
    ...
    (shroud 1.2.0) lib/shroud/email/incoming_email_handler.ex:140: Shroud.Email.IncomingEmailHandler.forward_incoming_email/4
```

## Root cause

`ParsedEmail.sanitize_email_address/1` stripped whitespace and invalid bracket notation from addresses but **not double quotes**.

Headers with a quoted display name and **no angle brackets** — e.g. `To: "Subscriber" foo@example.com` or `From: "Sales Team" promo@example.com` — have no `<...>`, so the parser treats the whole string as the address and (after stripping spaces) produces an invalid address that still contains quotes: `"Subscriber"foo@example.com`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

