### PR TITLE
feat: track per-day counts of blocked tracking domains

### DIFF
--- a/lib/shroud/email.ex
+++ b/lib/shroud/email.ex
@@ -33,14 +33,22 @@ defmodule Shroud.Email do
 
   def record_blocked_domains(domains) when is_list(domains) do
     today = Date.utc_today()
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
-    Enum.each(domains, fn domain ->
-      Repo.insert!(
-        %TrackerDomain{domain: domain, date: today, count: 1},
-        on_conflict: [inc: [count: 1]],
-        conflict_target: [:domain, :date]
-      )
-    end)
+    # One row per distinct domain; deduplicating also guarantees no domain
+    # appears twice in the same insert, which would break ON CONFLICT.
+    entries =
+      domains
+      |> Enum.uniq()
+      |> Enum.map(fn domain ->
+        %{domain: domain, date: today, count: 1, inserted_at: now, updated_at: now}
+      end)
+
+    # Single statement to avoid an N+1 when an email contains several trackers.
+    Repo.insert_all(TrackerDomain, entries,
+      on_conflict: [inc: [count: 1]],
+      conflict_target: [:domain, :date]
+    )
 
     :ok
   end

--- a/lib/shroud/email.ex
+++ b/lib/shroud/email.ex
@@ -5,6 +5,7 @@ defmodule Shroud.Email do
   alias Shroud.Aliases.EmailAlias
   alias Shroud.Accounts.User
   alias Shroud.Email.Tracker
+  alias Shroud.Email.TrackerDomain
   alias Shroud.Email.SpamEmail
   alias Shroud.Util
 
@@ -20,6 +21,28 @@ defmodule Shroud.Email do
     %Tracker{}
     |> Tracker.changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Records that each of the given tracking `domains` was blocked in an email
+  today, incrementing the per-day count for each one. Domains are expected to be
+  deduplicated already (one increment per domain per email).
+  """
+  @spec record_blocked_domains([String.t()]) :: :ok
+  def record_blocked_domains([]), do: :ok
+
+  def record_blocked_domains(domains) when is_list(domains) do
+    today = Date.utc_today()
+
+    Enum.each(domains, fn domain ->
+      Repo.insert!(
+        %TrackerDomain{domain: domain, date: today, count: 1},
+        on_conflict: [inc: [count: 1]],
+        conflict_target: [:domain, :date]
+      )
+    end)
+
+    :ok
   end
 
   @spec store_spam_email!(map(), User.t(), EmailAlias.t()) :: SpamEmail.t()

--- a/lib/shroud/email/enricher.ex
+++ b/lib/shroud/email/enricher.ex
@@ -84,7 +84,12 @@ defmodule Shroud.Email.Enricher do
   defp shroud_footer(%ParsedEmail{to: to_alias} = email) do
     {_sender_name, sender_address} = email.swoosh_email.from
 
-    trackers = email.removed_trackers
+    # Show the friendly tracker name where we have one, falling back to the raw
+    # domain for unknown pixels. Deduplicate so each label appears once.
+    trackers =
+      email.removed_trackers
+      |> Enum.map(fn %{name: name, domain: domain} -> name || domain end)
+      |> Enum.uniq()
 
     report_data =
       %{

--- a/lib/shroud/email/incoming_email_handler.ex
+++ b/lib/shroud/email/incoming_email_handler.ex
@@ -2,9 +2,10 @@ defmodule Shroud.Email.IncomingEmailHandler do
   alias Shroud.Accounts
   alias Shroud.Accounts.User
   alias Shroud.Aliases
+  alias Shroud.Domain
+  alias Shroud.Email
   alias Shroud.Mailer
   alias Shroud.Util
-  alias Shroud.Domain
 
   alias Shroud.Email.{
     SpamHandler,
@@ -131,16 +132,25 @@ defmodule Shroud.Email.IncomingEmailHandler do
         {:mailex, mailex_msg} -> ParsedEmail.parse(mailex_msg, sender, recipient)
       end
 
-    case parsed_email
-         |> TrackerRemover.process()
-         |> Enricher.process()
-         # Now our pipeline is done, we just want our Swoosh email
-         |> Map.get(:swoosh_email)
-         |> fix_incoming_sender_and_recipient(user.email, sender, recipient)
-         |> Mailer.deliver() do
+    processed =
+      parsed_email
+      |> TrackerRemover.process()
+      |> Enricher.process()
+
+    deliver_result =
+      processed
+      # Now our pipeline is done, we just want our Swoosh email
+      |> Map.get(:swoosh_email)
+      |> fix_incoming_sender_and_recipient(user.email, sender, recipient)
+      |> Mailer.deliver()
+
+    case deliver_result do
       {:ok, _id} ->
         email_alias = Aliases.get_email_alias_by_address!(recipient)
         Aliases.increment_forwarded!(email_alias)
+        # Record blocked tracking domains only once the email has actually been
+        # forwarded, so that retrying a failed Oban job can't inflate the counts.
+        Email.record_blocked_domains(ParsedEmail.blocked_domains(processed))
 
       {:error, {_code, %{"error" => error}}} ->
         Logger.error("Failed to forward email from #{sender} to #{user.email}: #{error}")

--- a/lib/shroud/email/incoming_email_handler.ex
+++ b/lib/shroud/email/incoming_email_handler.ex
@@ -5,6 +5,7 @@ defmodule Shroud.Email.IncomingEmailHandler do
   alias Shroud.Domain
   alias Shroud.Email
   alias Shroud.Mailer
+  alias Shroud.Repo
   alias Shroud.Util
 
   alias Shroud.Email.{
@@ -147,10 +148,15 @@ defmodule Shroud.Email.IncomingEmailHandler do
     case deliver_result do
       {:ok, _id} ->
         email_alias = Aliases.get_email_alias_by_address!(recipient)
-        Aliases.increment_forwarded!(email_alias)
+
         # Record blocked tracking domains only once the email has actually been
         # forwarded, so that retrying a failed Oban job can't inflate the counts.
-        Email.record_blocked_domains(ParsedEmail.blocked_domains(processed))
+        # Both counters live in one transaction so they can't diverge from each
+        # other if one write fails.
+        Repo.transaction(fn ->
+          Aliases.increment_forwarded!(email_alias)
+          Email.record_blocked_domains(ParsedEmail.blocked_domains(processed))
+        end)
 
       {:error, {_code, %{"error" => error}}} ->
         Logger.error("Failed to forward email from #{sender} to #{user.email}: #{error}")

--- a/lib/shroud/email/parsed_email.ex
+++ b/lib/shroud/email/parsed_email.ex
@@ -6,7 +6,14 @@ defmodule Shroud.Email.ParsedEmail do
   import Swoosh.Email
   require Logger
 
-  defstruct [:from, :to, :swoosh_email, :parsed_html, removed_trackers: []]
+  defstruct [
+    :from,
+    :to,
+    :swoosh_email,
+    :parsed_html,
+    removed_trackers: [],
+    blocked_domains: []
+  ]
 
   @type header_type :: {String.t(), String.t()}
   @type t :: %__MODULE__{
@@ -14,7 +21,8 @@ defmodule Shroud.Email.ParsedEmail do
           to: String.t(),
           swoosh_email: Swoosh.Email.t(),
           parsed_html: Floki.html_tree(),
-          removed_trackers: [String.t()]
+          removed_trackers: [String.t()],
+          blocked_domains: [String.t()]
         }
 
   @allowed_headers [

--- a/lib/shroud/email/parsed_email.ex
+++ b/lib/shroud/email/parsed_email.ex
@@ -6,14 +6,14 @@ defmodule Shroud.Email.ParsedEmail do
   import Swoosh.Email
   require Logger
 
-  defstruct [
-    :from,
-    :to,
-    :swoosh_email,
-    :parsed_html,
-    removed_trackers: [],
-    blocked_domains: []
-  ]
+  defstruct [:from, :to, :swoosh_email, :parsed_html, removed_trackers: []]
+
+  @typedoc """
+  A tracker removed from an email. `domain` is the real host extracted from the
+  pixel URL (used for persistence/analytics); `name` is the friendly name of a
+  known tracker, or `nil` for an unknown pixel (used for the user-facing report).
+  """
+  @type removed_tracker :: %{name: String.t() | nil, domain: String.t() | nil}
 
   @type header_type :: {String.t(), String.t()}
   @type t :: %__MODULE__{
@@ -21,8 +21,7 @@ defmodule Shroud.Email.ParsedEmail do
           to: String.t(),
           swoosh_email: Swoosh.Email.t(),
           parsed_html: Floki.html_tree(),
-          removed_trackers: [String.t()],
-          blocked_domains: [String.t()]
+          removed_trackers: [removed_tracker()]
         }
 
   @allowed_headers [

--- a/lib/shroud/email/parsed_email.ex
+++ b/lib/shroud/email/parsed_email.ex
@@ -33,6 +33,18 @@ defmodule Shroud.Email.ParsedEmail do
     "delivered-to"
   ]
 
+  @doc """
+  The distinct tracking domains discovered in this email, ready to be persisted.
+  Excludes entries without a resolvable host.
+  """
+  @spec blocked_domains(t()) :: [String.t()]
+  def blocked_domains(%__MODULE__{removed_trackers: removed_trackers}) do
+    removed_trackers
+    |> Enum.map(& &1.domain)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
   @spec parse(:mimemail.mimetuple() | Mailex.Message.t(), String.t(), String.t()) :: t
   def parse(%Mailex.Message{} = mailex_msg, from, to) do
     swoosh_email = build_email_from_mailex(new(), mailex_msg)

--- a/lib/shroud/email/tracker_domain.ex
+++ b/lib/shroud/email/tracker_domain.ex
@@ -1,0 +1,24 @@
+defmodule Shroud.Email.TrackerDomain do
+  @moduledoc """
+  A per-day count of how often a tracking domain was blocked. Each row records
+  the number of emails containing a tracking pixel from a given domain on a
+  given day, letting us chart how trackers trend over time.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tracker_domain_metrics" do
+    field :domain, :string
+    field :date, :date
+    field :count, :integer, default: 0
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tracker_domain, attrs) do
+    tracker_domain
+    |> cast(attrs, [:domain, :date, :count])
+    |> validate_required([:domain, :date, :count])
+  end
+end

--- a/lib/shroud/email/tracker_remover.ex
+++ b/lib/shroud/email/tracker_remover.ex
@@ -24,61 +24,59 @@ defmodule Shroud.Email.TrackerRemover do
   def process(%ParsedEmail{parsed_html: parsed_html} = email) do
     trackers = Email.list_trackers()
 
-    # Each removed image accumulates a `{report_label, domain}` tuple. The label
-    # is what we show the user in the email report (a friendly tracker name for
-    # known trackers, or the host for unknown pixels); the domain is always the
-    # real host extracted from the image URL, which is what we persist.
-    {processed_html, removed} =
+    # Each removed image accumulates a `%{name, domain}` entry: `name` is the
+    # friendly tracker name (nil for unknown pixels) shown in the user's report,
+    # and `domain` is the real host extracted from the image URL, which is what
+    # we persist for analytics.
+    {processed_html, removed_trackers} =
       Floki.traverse_and_update(parsed_html, [], fn
         {"img", attrs, children}, acc -> process_image(trackers, attrs, children, acc)
         other, acc -> {other, acc}
       end)
 
     # Entries are accumulated by prepending, so reverse to restore the order in
-    # which they appeared in the email.
-    removed = Enum.reverse(removed)
-
-    # Deduplicate so the same tracker isn't reported multiple times.
+    # which they appeared in the email, then deduplicate so an identical tracker
+    # isn't recorded multiple times.
     removed_trackers =
-      removed
-      |> Enum.map(fn {label, _domain} -> label end)
+      removed_trackers
+      |> Enum.reverse()
       |> Enum.uniq()
 
-    # Deduplicate per email so each domain is counted at most once per message.
-    blocked_domains =
-      removed
-      |> Enum.map(fn {_label, domain} -> domain end)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.uniq()
-
-    Email.record_blocked_domains(blocked_domains)
+    record_blocked_domains(removed_trackers)
 
     swoosh_email = struct(email.swoosh_email, html_body: Floki.raw_html(processed_html))
 
     struct(email,
       parsed_html: processed_html,
       removed_trackers: removed_trackers,
-      blocked_domains: blocked_domains,
       swoosh_email: swoosh_email
     )
+  end
+
+  # Persist a per-day count for each distinct domain in this email.
+  defp record_blocked_domains(removed_trackers) do
+    removed_trackers
+    |> Enum.map(& &1.domain)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Email.record_blocked_domains()
   end
 
   defp process_image(trackers, attrs, children, acc) do
     source = src_value(attrs)
 
-    # Look for known trackers (matched by pattern). We report the friendly name
-    # but persist the real host from the image URL.
+    # Look for known trackers (matched by pattern), then fall back to detecting
+    # tracking pixels from unknown sources by their size.
     entry =
       case known_tracker_name(trackers, attrs) do
         nil ->
-          # Look for tracking pixels from unknown sources, identified by size.
           case find_unknown_tracker(attrs) do
             nil -> nil
-            host -> {host, host}
+            host -> %{name: nil, domain: host}
           end
 
         name ->
-          {name, host_of(source)}
+          %{name: name, domain: host_of(source)}
       end
 
     if is_nil(entry) do

--- a/lib/shroud/email/tracker_remover.ex
+++ b/lib/shroud/email/tracker_remover.ex
@@ -42,8 +42,6 @@ defmodule Shroud.Email.TrackerRemover do
       |> Enum.reverse()
       |> Enum.uniq()
 
-    record_blocked_domains(removed_trackers)
-
     swoosh_email = struct(email.swoosh_email, html_body: Floki.raw_html(processed_html))
 
     struct(email,
@@ -51,15 +49,6 @@ defmodule Shroud.Email.TrackerRemover do
       removed_trackers: removed_trackers,
       swoosh_email: swoosh_email
     )
-  end
-
-  # Persist a per-day count for each distinct domain in this email.
-  defp record_blocked_domains(removed_trackers) do
-    removed_trackers
-    |> Enum.map(& &1.domain)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-    |> Email.record_blocked_domains()
   end
 
   defp process_image(trackers, attrs, children, acc) do

--- a/lib/shroud/email/tracker_remover.ex
+++ b/lib/shroud/email/tracker_remover.ex
@@ -24,53 +24,88 @@ defmodule Shroud.Email.TrackerRemover do
   def process(%ParsedEmail{parsed_html: parsed_html} = email) do
     trackers = Email.list_trackers()
 
-    {processed_html, removed_trackers} =
+    # Each removed image accumulates a `{report_label, domain}` tuple. The label
+    # is what we show the user in the email report (a friendly tracker name for
+    # known trackers, or the host for unknown pixels); the domain is always the
+    # real host extracted from the image URL, which is what we persist.
+    {processed_html, removed} =
       Floki.traverse_and_update(parsed_html, [], fn
         {"img", attrs, children}, acc -> process_image(trackers, attrs, children, acc)
         other, acc -> {other, acc}
       end)
 
-    # Trackers are accumulated by prepending, so reverse to restore the order in
-    # which they appeared in the email, then deduplicate so the same tracker
-    # isn't reported multiple times.
+    # Entries are accumulated by prepending, so reverse to restore the order in
+    # which they appeared in the email.
+    removed = Enum.reverse(removed)
+
+    # Deduplicate so the same tracker isn't reported multiple times.
     removed_trackers =
-      removed_trackers
-      |> Enum.reverse()
+      removed
+      |> Enum.map(fn {label, _domain} -> label end)
       |> Enum.uniq()
+
+    # Deduplicate per email so each domain is counted at most once per message.
+    blocked_domains =
+      removed
+      |> Enum.map(fn {_label, domain} -> domain end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    Email.record_blocked_domains(blocked_domains)
 
     swoosh_email = struct(email.swoosh_email, html_body: Floki.raw_html(processed_html))
 
     struct(email,
       parsed_html: processed_html,
       removed_trackers: removed_trackers,
+      blocked_domains: blocked_domains,
       swoosh_email: swoosh_email
     )
   end
 
   defp process_image(trackers, attrs, children, acc) do
-    # Look for known trackers
-    removed_tracker =
-      attrs
-      |> Enum.map(&check_attribute(trackers, &1))
-      |> Enum.find(%{name: nil}, &(not is_nil(&1)))
-      |> Map.get(:name)
+    source = src_value(attrs)
 
-    # Look for tracking pixels from unknown sources
-    removed_tracker =
-      if is_nil(removed_tracker) do
-        find_unknown_tracker(attrs)
-      else
-        removed_tracker
+    # Look for known trackers (matched by pattern). We report the friendly name
+    # but persist the real host from the image URL.
+    entry =
+      case known_tracker_name(trackers, attrs) do
+        nil ->
+          # Look for tracking pixels from unknown sources, identified by size.
+          case find_unknown_tracker(attrs) do
+            nil -> nil
+            host -> {host, host}
+          end
+
+        name ->
+          {name, host_of(source)}
       end
 
-    if is_nil(removed_tracker) do
+    if is_nil(entry) do
       attrs = attrs |> Enum.map(&proxify_src/1)
       {{"img", attrs, children}, acc}
     else
       # Returning nil removes this img element from the HTML
-      {nil, [removed_tracker | acc]}
+      {nil, [entry | acc]}
     end
   end
+
+  defp known_tracker_name(trackers, attrs) do
+    attrs
+    |> Enum.map(&check_attribute(trackers, &1))
+    |> Enum.find(%{name: nil}, &(not is_nil(&1)))
+    |> Map.get(:name)
+  end
+
+  defp src_value(attrs) do
+    case Enum.find(attrs, &match?({"src", _src}, &1)) do
+      {"src", source} -> source
+      _ -> nil
+    end
+  end
+
+  defp host_of(nil), do: nil
+  defp host_of(source), do: source |> URI.parse() |> Map.get(:host)
 
   defp check_attribute(trackers, {"src", source}) do
     Enum.find(trackers, fn tracker -> Tracker.match?(tracker, source) end)

--- a/priv/repo/migrations/20260620192543_create_tracker_domain_metrics.exs
+++ b/priv/repo/migrations/20260620192543_create_tracker_domain_metrics.exs
@@ -3,7 +3,7 @@ defmodule Shroud.Repo.Migrations.CreateTrackerDomainMetrics do
 
   def change do
     create table(:tracker_domain_metrics) do
-      add :domain, :string, null: false
+      add :domain, :text, null: false
       add :date, :date, null: false
       add :count, :bigint, default: 0, null: false
 

--- a/priv/repo/migrations/20260620192543_create_tracker_domain_metrics.exs
+++ b/priv/repo/migrations/20260620192543_create_tracker_domain_metrics.exs
@@ -1,0 +1,15 @@
+defmodule Shroud.Repo.Migrations.CreateTrackerDomainMetrics do
+  use Ecto.Migration
+
+  def change do
+    create table(:tracker_domain_metrics) do
+      add :domain, :string, null: false
+      add :date, :date, null: false
+      add :count, :bigint, default: 0, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:tracker_domain_metrics, [:domain, :date])
+  end
+end

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -1113,15 +1113,17 @@ defmodule Shroud.Email.EmailHandlerTest do
       end)
     end
 
-    test "records blocked tracking domains after a successful forward", %{
-      email_alias: email_alias
-    } do
+    test "records blocked tracking domains and the forwarded count together after a successful forward",
+         %{email_alias: email_alias} do
       args = tracking_pixel_email_args(email_alias)
 
       perform_job(EmailHandler, args)
 
+      # Both counters are written in one transaction on successful delivery.
       assert %TrackerDomain{count: 1} =
                Repo.get_by(TrackerDomain, domain: "spy.example.com", date: Date.utc_today())
+
+      assert Aliases.get_email_alias_by_address!(email_alias.address).forwarded == 1
     end
 
     test "a failed delivery does not record domains, and a retry does not inflate the count", %{

--- a/test/shroud/email/email_handler_test.exs
+++ b/test/shroud/email/email_handler_test.exs
@@ -1,3 +1,14 @@
+defmodule Shroud.Email.EmailHandlerTest.FailingMailerAdapter do
+  @moduledoc "Test-only Swoosh adapter that always fails delivery."
+  @behaviour Swoosh.Adapter
+
+  @impl true
+  def deliver(_email, _config), do: {:error, :simulated_smtp_failure}
+
+  @impl true
+  def validate_config(_config), do: :ok
+end
+
 defmodule Shroud.Email.EmailHandlerTest do
   use Shroud.DataCase, async: false
   use Oban.Testing, repo: Shroud.Repo
@@ -7,8 +18,10 @@ defmodule Shroud.Email.EmailHandlerTest do
 
   import Shroud.{AccountsFixtures, AliasesFixtures, DomainFixtures, EmailFixtures}
 
+  alias Shroud.Repo
   alias Shroud.Email
-  alias Shroud.Email.EmailHandler
+  alias Shroud.Email.{EmailHandler, TrackerDomain}
+  alias Shroud.Email.EmailHandlerTest.FailingMailerAdapter
   alias Shroud.{Aliases, Util, Accounts}
   use ShroudWeb, :verified_routes
 
@@ -1098,6 +1111,65 @@ defmodule Shroud.Email.EmailHandlerTest do
         assert email.text_body =~ "Text part"
         assert email.html_body =~ "HTML part"
       end)
+    end
+
+    test "records blocked tracking domains after a successful forward", %{
+      email_alias: email_alias
+    } do
+      args = tracking_pixel_email_args(email_alias)
+
+      perform_job(EmailHandler, args)
+
+      assert %TrackerDomain{count: 1} =
+               Repo.get_by(TrackerDomain, domain: "spy.example.com", date: Date.utc_today())
+    end
+
+    test "a failed delivery does not record domains, and a retry does not inflate the count", %{
+      email_alias: email_alias
+    } do
+      args = tracking_pixel_email_args(email_alias)
+
+      # Attempt 1: delivery fails before we ever forward the email. Nothing should
+      # be recorded, otherwise an Oban retry would inflate the counts.
+      capture_log(fn ->
+        with_failing_mailer(fn -> perform_job(EmailHandler, args) end)
+      end)
+
+      assert Repo.aggregate(TrackerDomain, :count) == 0
+
+      # Attempt 2 (the Oban retry): delivery succeeds. The domain is now counted
+      # exactly once -- not twice.
+      perform_job(EmailHandler, args)
+
+      assert %TrackerDomain{count: 1} =
+               Repo.get_by(TrackerDomain, domain: "spy.example.com", date: Date.utc_today())
+
+      assert Repo.aggregate(TrackerDomain, :count) == 1
+    end
+  end
+
+  defp tracking_pixel_email_args(email_alias) do
+    %{
+      from: "sender@example.com",
+      to: email_alias.address,
+      data:
+        html_email(
+          "sender@example.com",
+          [email_alias.address],
+          "Subject",
+          ~s(<html><body><p>hi</p><img src="https://spy.example.com" width="1" height="1" /></body></html>)
+        )
+    }
+  end
+
+  defp with_failing_mailer(fun) do
+    original = Application.get_env(:shroud, Shroud.Mailer)
+    Application.put_env(:shroud, Shroud.Mailer, adapter: FailingMailerAdapter)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:shroud, Shroud.Mailer, original)
     end
   end
 end

--- a/test/shroud/email/enricher_test.exs
+++ b/test/shroud/email/enricher_test.exs
@@ -1,0 +1,56 @@
+defmodule Shroud.Email.EnricherTest do
+  use ExUnit.Case, async: true
+  use ShroudWeb, :verified_routes
+
+  alias Shroud.Util
+  alias Shroud.Email.{Enricher, ParsedEmail}
+
+  defp build_email(removed_trackers) do
+    html = "<html><body><p>hi</p></body></html>"
+    {:ok, parsed_html} = Floki.parse_document(html)
+    swoosh = Swoosh.Email.new(from: {"", "sender@example.com"}, html_body: html)
+
+    %ParsedEmail{
+      to: "alias@shroud.test",
+      from: "sender@example.com",
+      swoosh_email: swoosh,
+      parsed_html: parsed_html,
+      removed_trackers: removed_trackers
+    }
+  end
+
+  test "uses the friendly tracker name in the report, falling back to the domain" do
+    email =
+      build_email([
+        %{name: "MailChimp", domain: "list-manage.com"},
+        %{name: nil, domain: "unknowntracker.com"}
+      ])
+
+    result = Enricher.process(email)
+
+    expected_data =
+      %{
+        sender: "sender@example.com",
+        email_alias: "alias@shroud.test",
+        trackers: ["MailChimp", "unknowntracker.com"]
+      }
+      |> Util.uri_encode_map!()
+
+    expected_url = ShroudWeb.Endpoint.url() <> ~p"/email-report/#{expected_data}"
+
+    assert result.swoosh_email.html_body =~ expected_url
+    assert result.swoosh_email.html_body =~ "removed 2 trackers."
+  end
+
+  test "deduplicates repeated labels in the report" do
+    email =
+      build_email([
+        %{name: "Mailgun", domain: "a.example.com"},
+        %{name: "Mailgun", domain: "b.example.com"}
+      ])
+
+    result = Enricher.process(email)
+
+    assert result.swoosh_email.html_body =~ "removed 1 tracker."
+  end
+end

--- a/test/shroud/email/tracker_remover_test.exs
+++ b/test/shroud/email/tracker_remover_test.exs
@@ -337,7 +337,10 @@ defmodule Shroud.Email.TrackerRemoverTest do
       assert email.removed_trackers == []
     end
 
-    test "persists a per-day count of 1 for each blocked domain in the email" do
+    test "does not persist counts itself (recording is the caller's job, post-delivery)" do
+      # process/1 is a pure transform. Persistence happens only once the email is
+      # successfully forwarded, so that re-running the pipeline on an Oban retry
+      # can't inflate the counts.
       html_body = """
       <html><body>
         <img src="https://spyonu.com/track?q=123" />
@@ -347,29 +350,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       process_html(html_body)
 
-      today = Date.utc_today()
-
-      assert %TrackerDomain{count: 1} =
-               Repo.get_by(TrackerDomain, domain: "spyonu.com", date: today)
-
-      assert %TrackerDomain{count: 1} =
-               Repo.get_by(TrackerDomain, domain: "unknowntracker.com", date: today)
-    end
-
-    test "increments the count when the same domain appears in a later email" do
-      html_body = """
-      <html><body>
-        <img src="https://unknowntracker.com" width="1" height="1" />
-      </body></html>
-      """
-
-      process_html(html_body)
-      process_html(html_body)
-
-      today = Date.utc_today()
-
-      assert %TrackerDomain{count: 2} =
-               Repo.get_by(TrackerDomain, domain: "unknowntracker.com", date: today)
+      assert Repo.aggregate(TrackerDomain, :count) == 0
     end
   end
 

--- a/test/shroud/email/tracker_remover_test.exs
+++ b/test/shroud/email/tracker_remover_test.exs
@@ -1,6 +1,7 @@
 defmodule Shroud.Email.TrackerRemoverTest do
   use Shroud.DataCase, async: true
-  alias Shroud.Email.{ParsedEmail, TrackerRemover}
+  alias Shroud.Repo
+  alias Shroud.Email.{ParsedEmail, TrackerDomain, TrackerRemover}
 
   import Shroud.{EmailFixtures, TrackerFixtures}
 
@@ -275,6 +276,105 @@ defmodule Shroud.Email.TrackerRemoverTest do
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(html_body)
       assert Enum.empty?(email.removed_trackers)
     end
+  end
+
+  describe "blocked domain tracking" do
+    test "records the actual pixel host for known trackers (not the tracker name)" do
+      html_body = """
+      <html><body>
+        <img src="https://spyonu.com/track?q=123" />
+      </body></html>
+      """
+
+      email = process_html(html_body)
+
+      # The report still shows the friendly tracker name...
+      assert email.removed_trackers == ["SpyOnU"]
+      # ...but we persist the real domain.
+      assert email.blocked_domains == ["spyonu.com"]
+    end
+
+    test "records hosts for unknown tracking pixels" do
+      html_body = """
+      <html><body>
+        <img src="https://unknowntracker.com" width="1" height="1" />
+        <img src="https://tracker2.com" width="2" height="2" />
+      </body></html>
+      """
+
+      email = process_html(html_body)
+
+      assert Enum.sort(email.blocked_domains) == ["tracker2.com", "unknowntracker.com"]
+    end
+
+    test "deduplicates domains within a single email" do
+      html_body = """
+      <html><body>
+        <img src="https://spyonu.com/track?q=123" />
+        <img src="https://spyonu.com/track?q=456" />
+        <img src="https://unknowntracker.com" width="1" height="1" />
+        <img src="https://unknowntracker.com" width="1" height="1" />
+      </body></html>
+      """
+
+      email = process_html(html_body)
+
+      assert Enum.sort(email.blocked_domains) == ["spyonu.com", "unknowntracker.com"]
+    end
+
+    test "is empty when no trackers are found" do
+      html_body = """
+      <html><body>
+        <img src="https://gooddomain.com/abc.jpg" alt="an image" />
+      </body></html>
+      """
+
+      email = process_html(html_body)
+
+      assert email.blocked_domains == []
+    end
+
+    test "persists a per-day count of 1 for each blocked domain in the email" do
+      html_body = """
+      <html><body>
+        <img src="https://spyonu.com/track?q=123" />
+        <img src="https://unknowntracker.com" width="1" height="1" />
+      </body></html>
+      """
+
+      process_html(html_body)
+
+      today = Date.utc_today()
+
+      assert %TrackerDomain{count: 1} =
+               Repo.get_by(TrackerDomain, domain: "spyonu.com", date: today)
+
+      assert %TrackerDomain{count: 1} =
+               Repo.get_by(TrackerDomain, domain: "unknowntracker.com", date: today)
+    end
+
+    test "increments the count when the same domain appears in a later email" do
+      html_body = """
+      <html><body>
+        <img src="https://unknowntracker.com" width="1" height="1" />
+      </body></html>
+      """
+
+      process_html(html_body)
+      process_html(html_body)
+
+      today = Date.utc_today()
+
+      assert %TrackerDomain{count: 2} =
+               Repo.get_by(TrackerDomain, domain: "unknowntracker.com", date: today)
+    end
+  end
+
+  defp process_html(html_body) do
+    html_email("sender@example.com", ["recipient@example.com"], "Subject", html_body)
+    |> :mimemail.decode()
+    |> ParsedEmail.parse("sender@example.com", "recipient@example.com")
+    |> TrackerRemover.process()
   end
 
   defp remove_whitespace(text), do: String.replace(text, ~r/\s/, "")

--- a/test/shroud/email/tracker_remover_test.exs
+++ b/test/shroud/email/tracker_remover_test.exs
@@ -44,7 +44,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
       assert Enum.empty?(Floki.find(email.parsed_html, "img"))
-      assert email.removed_trackers == ["SpyOnU"]
+      assert email.removed_trackers == [%{name: "SpyOnU", domain: "spyonu.com"}]
     end
 
     test "removes 1x1 (and 2x2) images" do
@@ -79,8 +79,8 @@ defmodule Shroud.Email.TrackerRemoverTest do
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
       assert length(Floki.find(email.parsed_html, "img")) == 1
       assert length(email.removed_trackers) == 2
-      assert Enum.member?(email.removed_trackers, "unknowntracker.com")
-      assert Enum.member?(email.removed_trackers, "tracker2.com")
+      assert Enum.member?(email.removed_trackers, %{name: nil, domain: "unknowntracker.com"})
+      assert Enum.member?(email.removed_trackers, %{name: nil, domain: "tracker2.com"})
     end
 
     test "removes 1x1 images with 'px' in height" do
@@ -114,7 +114,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
       assert length(Floki.find(email.parsed_html, "img")) == 1
       assert length(email.removed_trackers) == 1
-      assert hd(email.removed_trackers) == "unknowntracker.com"
+      assert hd(email.removed_trackers) == %{name: nil, domain: "unknowntracker.com"}
     end
 
     test "doesn't double-count 1x1 images from known trackers" do
@@ -145,7 +145,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
       assert Floki.find(email.parsed_html, "img") |> Enum.empty?()
-      assert email.removed_trackers == ["SpyOnU"]
+      assert email.removed_trackers == [%{name: "SpyOnU", domain: "spyonu.com"}]
     end
 
     test "deduplicates repeated trackers" do
@@ -179,7 +179,11 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       assert remove_whitespace(email.swoosh_email.html_body) == remove_whitespace(expected_result)
       assert Enum.empty?(Floki.find(email.parsed_html, "img"))
-      assert email.removed_trackers == ["SpyOnU", "unknowntracker.com"]
+
+      assert email.removed_trackers == [
+               %{name: "SpyOnU", domain: "spyonu.com"},
+               %{name: nil, domain: "unknowntracker.com"}
+             ]
     end
 
     test "proxies non-tracker images" do
@@ -279,7 +283,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
   end
 
   describe "blocked domain tracking" do
-    test "records the actual pixel host for known trackers (not the tracker name)" do
+    test "carries both the friendly name and the real domain for known trackers" do
       html_body = """
       <html><body>
         <img src="https://spyonu.com/track?q=123" />
@@ -288,10 +292,9 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       email = process_html(html_body)
 
-      # The report still shows the friendly tracker name...
-      assert email.removed_trackers == ["SpyOnU"]
-      # ...but we persist the real domain.
-      assert email.blocked_domains == ["spyonu.com"]
+      # A single entry holds the friendly name (for the report) and the real
+      # host (for persistence).
+      assert email.removed_trackers == [%{name: "SpyOnU", domain: "spyonu.com"}]
     end
 
     test "records hosts for unknown tracking pixels" do
@@ -304,7 +307,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       email = process_html(html_body)
 
-      assert Enum.sort(email.blocked_domains) == ["tracker2.com", "unknowntracker.com"]
+      assert Enum.sort(domains(email)) == ["tracker2.com", "unknowntracker.com"]
     end
 
     test "deduplicates domains within a single email" do
@@ -319,7 +322,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       email = process_html(html_body)
 
-      assert Enum.sort(email.blocked_domains) == ["spyonu.com", "unknowntracker.com"]
+      assert Enum.sort(domains(email)) == ["spyonu.com", "unknowntracker.com"]
     end
 
     test "is empty when no trackers are found" do
@@ -331,7 +334,7 @@ defmodule Shroud.Email.TrackerRemoverTest do
 
       email = process_html(html_body)
 
-      assert email.blocked_domains == []
+      assert email.removed_trackers == []
     end
 
     test "persists a per-day count of 1 for each blocked domain in the email" do
@@ -375,6 +378,13 @@ defmodule Shroud.Email.TrackerRemoverTest do
     |> :mimemail.decode()
     |> ParsedEmail.parse("sender@example.com", "recipient@example.com")
     |> TrackerRemover.process()
+  end
+
+  defp domains(email) do
+    email.removed_trackers
+    |> Enum.map(& &1.domain)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
   end
 
   defp remove_whitespace(text), do: String.replace(text, ~r/\s/, "")

--- a/test/shroud/email_test.exs
+++ b/test/shroud/email_test.exs
@@ -2,7 +2,7 @@ defmodule Shroud.EmailTest do
   use Shroud.DataCase, async: true
   alias Shroud.Repo
   alias Shroud.Email
-  alias Shroud.Email.Tracker
+  alias Shroud.Email.{Tracker, TrackerDomain}
   import Shroud.{AccountsFixtures, AliasesFixtures, EmailFixtures}
 
   setup do
@@ -22,6 +22,50 @@ defmodule Shroud.EmailTest do
       assert length(trackers) == 1
       assert hd(trackers).name == tracker.name
       assert hd(trackers).pattern == tracker.pattern
+    end
+  end
+
+  describe "record_blocked_domains/1" do
+    test "records a count of 1 per domain for today" do
+      Email.record_blocked_domains(["tracker.co", "spy.example.com"])
+
+      today = Date.utc_today()
+
+      assert %TrackerDomain{count: 1, date: ^today} =
+               Repo.get_by(TrackerDomain, domain: "tracker.co", date: today)
+
+      assert %TrackerDomain{count: 1, date: ^today} =
+               Repo.get_by(TrackerDomain, domain: "spy.example.com", date: today)
+    end
+
+    test "increments the count for a domain seen again on the same day" do
+      Email.record_blocked_domains(["tracker.co"])
+      Email.record_blocked_domains(["tracker.co"])
+      Email.record_blocked_domains(["tracker.co"])
+
+      today = Date.utc_today()
+
+      assert %TrackerDomain{count: 3} =
+               Repo.get_by(TrackerDomain, domain: "tracker.co", date: today)
+    end
+
+    test "keeps a separate count per (domain, date)" do
+      yesterday = Date.add(Date.utc_today(), -1)
+
+      Repo.insert!(%TrackerDomain{domain: "tracker.co", date: yesterday, count: 5})
+      Email.record_blocked_domains(["tracker.co"])
+
+      assert %TrackerDomain{count: 5} =
+               Repo.get_by(TrackerDomain, domain: "tracker.co", date: yesterday)
+
+      assert %TrackerDomain{count: 1} =
+               Repo.get_by(TrackerDomain, domain: "tracker.co", date: Date.utc_today())
+    end
+
+    test "does nothing for an empty list" do
+      Email.record_blocked_domains([])
+
+      assert Repo.aggregate(TrackerDomain, :count) == 0
     end
   end
 


### PR DESCRIPTION
## What

Persist the domain of every tracking pixel we block, with a per-day count, so we can chart how different tracking domains trend over time.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

