### PR TITLE
fix: add Oban v14 migration for missing 'suspended' enum value

### DIFF
--- a/priv/repo/migrations/20260620230000_update_oban_to_v14.exs
+++ b/priv/repo/migrations/20260620230000_update_oban_to_v14.exs
@@ -3,5 +3,5 @@ defmodule Shroud.Repo.Migrations.UpdateObanToV14 do
 
   def up, do: Oban.Migrations.up(version: 14)
 
-  def down, do: Oban.Migrations.down(version: 11)
+  def down, do: Oban.Migrations.down(version: 12)
 end

--- a/priv/repo/migrations/20260620230000_update_oban_to_v14.exs
+++ b/priv/repo/migrations/20260620230000_update_oban_to_v14.exs
@@ -1,0 +1,7 @@
+defmodule Shroud.Repo.Migrations.UpdateObanToV14 do
+  use Ecto.Migration
+
+  def up, do: Oban.Migrations.up(version: 14)
+
+  def down, do: Oban.Migrations.down(version: 11)
+end


### PR DESCRIPTION
## Problem

Production is throwing `Postgrex.Error ERROR 22P02 (invalid_text_representation) invalid input value for enum oban_job_state: "suspended"` on Oban unique-job inserts (`Oban.Engines.Basic.insert_unique` → `fetch_job`).

## Root cause

Oban was upgraded **2.19.2 → 2.23.0** in #125, but no database migration was added to bump the Oban schema past **v11**. Oban 2.23 ships schema **v14**, which adds a `suspended` value to the `oban_job_state` enum, and Oban's runtime now references that state in its queries. Since the production enum lacks `suspended`, every unique-job insert crashes.

This is **not** related to today's Elixir 1.20 upgrade (#133) — that just re-exercised the failing path.

## Fix

Adds a migration running `Oban.Migrations.up(version: 14)`, which incrementally applies Oban schema v12–v14 to bring the DB in line with the installed Oban version.

## Verification

Ran `mix ecto.migrate` against a fresh dev DB:
- `oban_job_state` enum now includes `suspended`
- Oban schema version comment on `oban_jobs` is now `14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

