### PR TITLE
feat: set up Sentry releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # Need full history + tags so `git describe` can compute the release.
+          fetch-depth: 0
+
+      # Release identifier reported to Sentry, e.g. v1.2.0-4-gabcd123.
+      # The same value is baked into the image and used to create the
+      # matching release in Sentry (see the sentry-release job).
+      - name: Compute release version
+        id: version
+        run: echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -77,6 +87,8 @@ jobs:
           context: .
           push: true
           platforms: ${{ matrix.docker_platform }}
+          build-args: |
+            SENTRY_RELEASE=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta_arch.outputs.tags }}
           labels: ${{ steps.meta_base.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.platform }}
@@ -208,3 +220,35 @@ jobs:
         uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: 'trivy-results.sarif'
+
+  sentry-release:
+    name: Create Sentry release
+    needs: merge-manifests
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # Full history + tags so `git describe` and commit association work.
+          fetch-depth: 0
+
+      - name: Compute release version
+        id: version
+        run: echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      # Creates the release in Sentry, associates the commits since the last
+      # release, finalizes it, and records a deploy in the "production"
+      # environment. The version must match SENTRY_RELEASE baked into the image.
+      - name: Create Sentry release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          version: ${{ steps.version.outputs.version }}
+          environment: production
+          set_commits: auto

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,7 @@
 name: Commitlint
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,12 @@ RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
 RUN update-ca-certificates
 
 ARG MIX_ENV
+
+# Release identifier (e.g. v1.2.0-4-gabcd123) reported to Sentry at runtime.
+# Passed in by the CI build; defaults to "unknown" for local builds.
+ARG SENTRY_RELEASE="unknown"
+ENV SENTRY_RELEASE="${SENTRY_RELEASE}"
+
 ENV USER="elixir"
 
 WORKDIR "/home/${USER}/app"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -58,15 +58,3 @@ config :shroud, :mailer,
 #       force_ssl: [hsts: true]
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
-
-if System.get_env("SENTRY_DSN") do
-  config :sentry,
-    dsn: System.get_env("SENTRY_DSN"),
-    environment_name: Mix.env(),
-    integrations: [
-      oban: [
-        capture_errors: true,
-        cron: [enabled: true]
-      ]
-    ]
-end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -143,4 +143,19 @@ if config_env() == :prod do
     app_domain: app_domain,
     email_domain: email_domain,
     env: :prod
+
+  # Sentry error reporting. SENTRY_RELEASE is baked into the image at build
+  # time (see Dockerfile).
+  if sentry_dsn = System.get_env("SENTRY_DSN") do
+    config :sentry,
+      dsn: sentry_dsn,
+      environment_name: config_env(),
+      release: System.get_env("SENTRY_RELEASE"),
+      integrations: [
+        oban: [
+          capture_errors: true,
+          cron: [enabled: true]
+        ]
+      ]
+  end
 end


### PR DESCRIPTION
## Summary

Sets up [Sentry Releases](https://docs.sentry.io/product/releases/) so errors are attributed to a specific build, with commit association and deploy markers. Also fixes the existing Sentry config so the Oban integration actually applies in production.

## Changes

- **Tag events with a release.** The Docker image bakes a `git describe --tags` version (e.g. `v1.2.0-4-gabcd123`) into `SENTRY_RELEASE`, which the SDK reads automatically. Chosen over the mutable `:edge`/`:1` tags because it's unique per commit.
- **Create the release in CI.** A new `sentry-release` job (runs once after the image is published) uses `getsentry/action-release` to create the release, associate commits (`set_commits: auto`), finalize it, and record a `production` deploy — using the same `git describe` version baked into the image. Requires `fetch-depth: 0` so tags are available.
- **Fix Sentry config altitude.** Moved `config :sentry` from compile-time `config/prod.exs` to `config/runtime.exs`. `SENTRY_DSN` isn't present during the Docker build, so the compile-time block was skipped and the `integrations: [oban: ...]` config silently dropped in prod. Basic error capture still worked (the SDK reads `SENTRY_DSN`/`SENTRY_RELEASE` from the env at runtime), but the Oban integration did not.

## Required before this is useful

Repo secrets must be added: `SENTRY_AUTH_TOKEN` (scopes: `project:releases`, `org:read`), `SENTRY_ORG`, `SENTRY_PROJECT`. The Sentry↔GitHub integration must be connected for commit association. The `sentry-release` job no-ops/errors without `SENTRY_AUTH_TOKEN`.

## Notes

- No DB migrations. Config/CI only.
- The `production` deploy marker fires at build time; combined with the hosting repo's Watchtower auto-pull of `:edge` (~5 min poll), that's close to the real deploy moment.
- Verified via `mix format` (syntax) and reviewing the `docker compose config` merge; not run through the full test suite as these are infra/config changes. First `main` build is the real proof — confirm the job's version matches the `:edge`/`type=sha` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

