### PR TITLE
ci: fix warning in sentry-release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,6 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          version: ${{ steps.version.outputs.version }}
+          release: ${{ steps.version.outputs.version }}
           environment: production
           set_commits: auto


### PR DESCRIPTION
## Summary

`getsentry/action-release` 3.x deprecated the `version` input in favour of `release`. The first release run on `main` worked, but logged:

> `Input 'version' has been deprecated with message: Deprecated: Use "release" instead.`

This swaps `version:` → `release:` in the `sentry-release` job. Behaviour is unchanged.