### PR TITLE
fix: handle missing favicon

### DIFF
--- a/lib/shroud_web/endpoint.ex
+++ b/lib/shroud_web/endpoint.ex
@@ -22,6 +22,9 @@ defmodule ShroudWeb.Endpoint do
     from: :shroud,
     gzip: false,
     only: ShroudWeb.static_paths(),
+    # `only` matches the digested favicon by exact name only; `only_matching`
+    # lets `favicon-<hash>.ico` (referenced by ~p in prod) be served too.
+    only_matching: ~w(favicon),
     headers: %{"Access-Control-Allow-Origin" => "*"}
 
   # Code reloading can be explicitly enabled under the


### PR DESCRIPTION
## Problem

The favicon doesn't show on `app.shroud.email` (Firefox renders the generic globe), even though `/favicon.ico` returns `200`.

In production, `~p"/favicon.ico"` resolves through the asset manifest to the **digested** filename, so the served HTML contains:

```html
<link rel="icon" href="/favicon-45233c6eb1542e6f6f5077a4862b7133.ico?vsn=d">
```

That hashed URL returns **404**, so the browser never gets a favicon. The undigested `/favicon.ico` returns `200`, but the browser never requests it.

## Root cause

`Plug.Static` was configured with `only: ShroudWeb.static_paths()` (`~w(assets fonts images favicon.ico robots.txt)`). Its `:only` filter does an **exact first-segment** match:

- `assets/app-<hash>.css` → first segment `assets` is whitelisted → served ✅
- `favicon-<hash>.ico` → first segment is the whole hashed name, which ≠ `favicon.ico` → **404** ❌

Assets/fonts/images are unaffected because they're whitelisted by directory, under which all digested files match. Only root-level digested files (favicon) hit this.

## Fix

Add `only_matching: ~w(favicon)` — Plug.Static's documented remedy for serving digested files at the root. Verified by reproducing the exact config against a temp dir:

| request | before (`only:`) | after (`+ only_matching`) |
|---|---|---|
| `favicon-<hash>.ico` | 404 | **200** |
| `assets/app-<hash>.css` | 200 | 200 |

## Notes

- No image/template changes — the existing `favicon.ico` is fine.
- Takes effect on deploy; Firefox caches favicons aggressively, so a hard refresh may be needed to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

