### PR TITLE
chore: align templates with AGENTS.md guidelines

### DIFF
--- a/lib/shroud/proxy.ex
+++ b/lib/shroud/proxy.ex
@@ -39,8 +39,6 @@ defmodule Shroud.Proxy do
             List.keyfind(headers, "Content-Type", 0, {"Content-Type", nil})
 
           {:ok, {body, content_type}}
-
-          {:ok, {body, content_type}}
         else
           {:error, :not_an_image}
         end

--- a/lib/shroud_web/components/layouts/app.html.heex
+++ b/lib/shroud_web/components/layouts/app.html.heex
@@ -2,15 +2,15 @@
   <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
     <div class="px-4 py-4 sm:px-0">
       <p :if={Flash.get(@flash, :info)} class="alert alert-info mb-6" role="alert">
-        <%= Flash.get(@flash, :info) %>
+        {Flash.get(@flash, :info)}
       </p>
       <p :if={Flash.get(@flash, :error)} class="alert alert-error mb-6" role="alert">
-        <%= Flash.get(@flash, :error) %>
+        {Flash.get(@flash, :error)}
       </p>
 
       <.logging_warning current_user={@current_user} />
 
-      <%= @inner_content %>
+      {@inner_content}
     </div>
   </div>
 </main>

--- a/lib/shroud_web/components/layouts/error.html.heex
+++ b/lib/shroud_web/components/layouts/error.html.heex
@@ -11,6 +11,6 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
   </head>
   <body class="h-full">
-    <%= @inner_content %>
+    {@inner_content}
   </body>
 </html>

--- a/lib/shroud_web/components/layouts/navbar.html.heex
+++ b/lib/shroud_web/components/layouts/navbar.html.heex
@@ -33,7 +33,7 @@
         </div>
         <div class="hidden md:block">
           <div class="ml-4 flex items-center md:ml-6">
-            <!-- Profile dropdown -->
+            <%!-- Profile dropdown --%>
             <%= if @current_user do %>
               <%= if @current_user.status == :free do %>
                 <div class="text-gray-400 mr-2">
@@ -55,7 +55,7 @@
                     x-bind:aria-expanded="open.toString()"
                   >
                     <span class="sr-only">Open user menu</span>
-                    <!-- HeroIcons user-cirle -->
+                    <%!-- HeroIcons user-cirle --%>
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
@@ -70,7 +70,7 @@
           </div>
         </div>
         <div class="-mr-2 flex md:hidden">
-          <!-- Mobile menu button -->
+          <%!-- Mobile menu button --%>
           <button
             @click="open = !open"
             type="button"
@@ -79,19 +79,19 @@
             x-bind:aria-expanded="open.toString()"
           >
             <span class="sr-only">Open main menu</span>
-            <!--
+            <%!--
               Heroicon name: outline/menu
 
               Menu open: "hidden", Menu closed: "block"
-            -->
+            --%>
             <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
-            <!--
+            <%!--
               Heroicon name: outline/x
 
               Menu open: "block", Menu closed: "hidden"
-            -->
+            --%>
             <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -101,10 +101,10 @@
     </div>
   </div>
 
-  <!-- Mobile menu, show/hide based on menu state. -->
+  <%!-- Mobile menu, show/hide based on menu state. --%>
   <div x-show="open" class="border-b border-gray-700 md:hidden" id="mobile-menu">
     <div class="px-2 py-3 space-y-1 sm:px-3">
-      <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
+      <%!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" --%>
       <%= if @current_user do %>
         <.link href={~p"/"} class={active_class(@conn, ~p"/", "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium", "bg-gray-900 text-white")}>Aliases</.link>
         <.link href={~p"/detention"} class={active_class(@conn, ~p"/detention", "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium", "bg-gray-900 text-white")}>
@@ -124,7 +124,7 @@
       <%= if @current_user do %>
         <div class="flex items-center px-5">
           <div class="shrink-0 text-gray-400">
-            <!-- HeroIcons user-cirle -->
+            <%!-- HeroIcons user-cirle --%>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>

--- a/lib/shroud_web/components/layouts/settings.html.heex
+++ b/lib/shroud_web/components/layouts/settings.html.heex
@@ -1,10 +1,10 @@
 <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
   <.logging_warning current_user={@current_user} />
   <p :if={Flash.get(@flash, :info)} class="alert alert-info mb-6" role="alert">
-    <%= Flash.get(@flash, :info) %>
+    {Flash.get(@flash, :info)}
   </p>
   <p :if={Flash.get(@flash, :error)} class="alert alert-error mb-6" role="alert">
-    <%= Flash.get(@flash, :error) %>
+    {Flash.get(@flash, :error)}
   </p>
   <div class="lg:grid lg:grid-cols-12 lg:gap-x-5">
     <aside class="px-2 sm:px-6 lg:px-0 lg:col-span-3">
@@ -92,7 +92,7 @@
     </aside>
 
     <div class="space-y-6 sm:px-6 lg:px-0 lg:col-span-9">
-      <%= @inner_content %>
+      {@inner_content}
     </div>
   </div>
 </div>

--- a/lib/shroud_web/controllers/error_html/error_page.html.heex
+++ b/lib/shroud_web/controllers/error_html/error_page.html.heex
@@ -8,9 +8,9 @@
     </div>
     <div class="py-16">
       <div class="text-center">
-        <p class="text-sm font-semibold text-indigo-400 uppercase tracking-wide"><%= @error %> error</p>
-        <h1 class="mt-2 text-4xl font-extrabold text-gray-100 tracking-tight sm:text-5xl"><%= @heading %></h1>
-        <p class="mt-2 text-base text-gray-300"><%= @description %></p>
+        <p class="text-sm font-semibold text-indigo-400 uppercase tracking-wide">{@error} error</p>
+        <h1 class="mt-2 text-4xl font-extrabold text-gray-100 tracking-tight sm:text-5xl">{@heading}</h1>
+        <p class="mt-2 text-base text-gray-300">{@description}</p>
         <div class="mt-6">
           <a href="/" class="text-base font-medium text-indigo-400 hover:text-indigo-200">Go back home<span aria-hidden="true"> &rarr;</span></a>
         </div>

--- a/lib/shroud_web/controllers/page_html/email_report.html.heex
+++ b/lib/shroud_web/controllers/page_html/email_report.html.heex
@@ -5,8 +5,8 @@
   <h1 class="text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">Email report</h1>
 
   <p class="my-6 text-gray-800 dark:text-gray-200">
-    This email was sent from <span class="font-bold"><%= @sender %></span>
-    to <span class="font-bold"><%= @email_alias %></span>.
+    This email was sent from <span class="font-bold">{@sender}</span>
+    to <span class="font-bold">{@email_alias}</span>.
   </p>
 
   <%= if not Enum.empty?(@trackers) do %>
@@ -16,7 +16,7 @@
 
     <ul class="space-y-2 my-4">
       <%= for tracker <- @trackers do %>
-        <li class="block bg-slate-200 dark:bg-gray-700 rounded p-3 font-semibold text-gray-900 dark:text-gray-100"><%= tracker %></li>
+        <li class="block bg-slate-200 dark:bg-gray-700 rounded p-3 font-semibold text-gray-900 dark:text-gray-100">{tracker}</li>
       <% end %>
     </ul>
 

--- a/lib/shroud_web/controllers/user_confirmation_html/edit.html.heex
+++ b/lib/shroud_web/controllers/user_confirmation_html/edit.html.heex
@@ -7,7 +7,7 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={_f} for={%{}} as={:user} action={~p"/users/confirm/#{@token}"}>
+      <.form for={%{}} as={:user} id="confirm-form" action={~p"/users/confirm/#{@token}"}>
         <%= submit "Confirm my account", class: "btn btn-primary w-full" %>
       </.form>
     </div>

--- a/lib/shroud_web/controllers/user_confirmation_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_confirmation_html/new.html.heex
@@ -11,7 +11,7 @@
         We sent you an email with a confirmation link.
         Please click the link in this email to continue.
       </p>
-      <.form :let={f} for={%{}} as={:user} action={~p"/users/confirm"} class="mt-6">
+      <.form :let={f} id="resend-confirmation-form" for={%{}} as={:user} action={~p"/users/confirm"} class="mt-6">
         <%= hidden_input f, :email, required: true, value: @current_user.email %>
         <div>
           <%= submit "Resend confirmation email", class: "btn btn-primary w-full" %>

--- a/lib/shroud_web/controllers/user_registration_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_registration_html/new.html.heex
@@ -17,7 +17,7 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={f} for={@changeset} action={~p"/users/register"} as={:user} class="space-y-6">
+      <.form :let={f} for={@changeset} id="user-registration-form" action={~p"/users/register"} as={:user} class="space-y-6">
         <%= if @lifetime do %>
           <p class="text-sm text-gray-600 dark:text-gray-400 text-center">Signing up for a lifetime account.</p>
           <%= select f, :status, [:lifetime], selected: :lifetime, class: "hidden" %>

--- a/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
@@ -11,7 +11,7 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={f} for={%{}} as={:user} action={~p"/users/reset_password"} class="space-y-6">
+      <.form :let={f} for={%{}} as={:user} id="reset-password-form" action={~p"/users/reset_password"} class="space-y-6">
         <div>
           <%= label f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">

--- a/lib/shroud_web/controllers/user_session_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_session_html/new.html.heex
@@ -11,10 +11,10 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={f} for={@conn} action={~p"/users/log_in"} as={:user} class="space-y-6">
+      <.form :let={f} for={@conn} action={~p"/users/log_in"} as={:user} id="login-form" class="space-y-6">
         <%= if @error_message do %>
           <div class="alert alert-error">
-            <%= @error_message %>
+            {@error_message}
           </div>
         <% end %>
 

--- a/lib/shroud_web/controllers/user_session_html/totp.html.heex
+++ b/lib/shroud_web/controllers/user_session_html/totp.html.heex
@@ -11,7 +11,7 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={f} for={@conn} action={~p"/users/totp"} as={:user} class="space-y-6">
+      <.form :let={f} for={@conn} action={~p"/users/totp"} as={:user} id="totp-form" class="space-y-6">
         <%= hidden_input f, :action, name: "action", value: "totp" %>
 
         <p class="text-gray-700 dark:text-gray-300 text-sm text-center">Enter the code from your authenticator app to continue.</p>

--- a/lib/shroud_web/controllers/user_settings_html/appearance.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/appearance.html.heex
@@ -5,10 +5,13 @@
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Choose how Shroud.email looks to you.</p>
     </div>
 
-    <.form for={%{}} action={~p"/settings"} method="put">
+    <.form for={%{}} id="appearance-form" action={~p"/settings"} method="put">
       <input type="hidden" name="action" value="update_theme" />
       <fieldset class="space-y-3">
-        <label class={"flex items-center gap-3 rounded-lg border p-4 cursor-pointer #{if @current_user.theme == :system, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"}"}>
+        <label class={[
+          "flex items-center gap-3 rounded-lg border p-4 cursor-pointer",
+          if(@current_user.theme == :system, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700")
+        ]}>
           <input type="radio" name="theme" value="system" checked={@current_user.theme == :system} class="text-indigo-600 focus:ring-indigo-500" />
           <.icon name={:computer_desktop} class="h-5 w-5 text-gray-500 dark:text-gray-400" />
           <div>
@@ -17,7 +20,10 @@
           </div>
         </label>
 
-        <label class={"flex items-center gap-3 rounded-lg border p-4 cursor-pointer #{if @current_user.theme == :light, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"}"}>
+        <label class={[
+          "flex items-center gap-3 rounded-lg border p-4 cursor-pointer",
+          if(@current_user.theme == :light, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700")
+        ]}>
           <input type="radio" name="theme" value="light" checked={@current_user.theme == :light} class="text-indigo-600 focus:ring-indigo-500" />
           <.icon name={:sun} class="h-5 w-5 text-gray-500 dark:text-gray-400" />
           <div>
@@ -26,7 +32,10 @@
           </div>
         </label>
 
-        <label class={"flex items-center gap-3 rounded-lg border p-4 cursor-pointer #{if @current_user.theme == :dark, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"}"}>
+        <label class={[
+          "flex items-center gap-3 rounded-lg border p-4 cursor-pointer",
+          if(@current_user.theme == :dark, do: "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20", else: "border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700")
+        ]}>
           <input type="radio" name="theme" value="dark" checked={@current_user.theme == :dark} class="text-indigo-600 focus:ring-indigo-500" />
           <.icon name={:moon} class="h-5 w-5 text-gray-500 dark:text-gray-400" />
           <div>

--- a/lib/shroud_web/controllers/user_settings_html/signup.html.heex
+++ b/lib/shroud_web/controllers/user_settings_html/signup.html.heex
@@ -36,7 +36,7 @@
         <ul role="list" class="mt-8 space-y-5 lg:space-y-0 lg:grid lg:grid-cols-2 lg:gap-x-8 lg:gap-y-5">
           <li class="flex items-start lg:col-span-1">
             <div class="shrink-0">
-              <!-- Heroicon name: solid/check-circle -->
+              <%!-- Heroicon name: solid/check-circle --%>
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
               </svg>
@@ -48,7 +48,7 @@
 
           <li class="flex items-start lg:col-span-1">
             <div class="shrink-0">
-              <!-- Heroicon name: solid/check-circle -->
+              <%!-- Heroicon name: solid/check-circle --%>
               <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
               </svg>

--- a/lib/shroud_web/live/email_alias_live/index.html.heex
+++ b/lib/shroud_web/live/email_alias_live/index.html.heex
@@ -19,10 +19,10 @@
     <div class="mt-2">
       <div class="flex items-center">
         <.text_input name="alias_name" placeholder="john.doe" />
-        <span class="ml-3 text-sm text-gray-700 dark:text-gray-300"><%= @custom_alias_domain %></span>
+        <span class="ml-3 text-sm text-gray-700 dark:text-gray-300">{@custom_alias_domain}</span>
       </div>
       <p :if={@custom_alias_error} class="text-red-600 mt-1 text-sm">
-        <%= @custom_alias_error %>
+        {@custom_alias_error}
       </p>
     </div>
     <:buttons>
@@ -49,7 +49,7 @@
 <% else %>
   <div class="mb-3 flex items-center justify-between">
     <div class="text-gray-600 dark:text-gray-400 text-sm hidden sm:block">
-      <%= length(@aliases) %>
+      {length(@aliases)}
       <%= if length(@aliases) == 1 do %>
         alias
       <% else %>
@@ -144,20 +144,20 @@
                       </dd>
                     </dl>
                     <.link navigate={~p"/alias/#{email_alias.address}"} class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-500 dark:hover:text-gray-400">
-                      <%= email_alias.address %>
+                      {email_alias.address}
                     </.link>
                     <div class="text-sm text-gray-500 dark:text-gray-400">
-                      <%= email_alias.title %>
+                      {email_alias.title}
                     </div>
                     <dl class="text-sm lg:hidden">
                       <dt class="sr-only sm:hidden">Forwarded</dt>
-                      <dd class="mt-1 truncate text-gray-500 dark:text-gray-400 sm:hidden"><%= email_alias.forwarded %> forwarded</dd>
+                      <dd class="mt-1 truncate text-gray-500 dark:text-gray-400 sm:hidden">{email_alias.forwarded} forwarded</dd>
                     </dl>
                   </div>
                 </td>
                 <td class="hidden px-6 py-4 whitespace-nowrap sm:table-cell">
-                  <div class="text-sm text-gray-900 dark:text-gray-100"><%= email_alias.forwarded %></div>
-                  <div class="text-sm text-gray-500 dark:text-gray-400"><%= email_alias.forwarded_in_last_30_days %> in the last month</div>
+                  <div class="text-sm text-gray-900 dark:text-gray-100">{email_alias.forwarded}</div>
+                  <div class="text-sm text-gray-500 dark:text-gray-400">{email_alias.forwarded_in_last_30_days} in the last month</div>
                 </td>
                 <td class="hidden px-6 py-4 whitespace-nowrap lg:table-cell">
                   <%= if email_alias.enabled do %>
@@ -171,7 +171,7 @@
                   <% end %>
                 </td>
                 <td class="hidden px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 sm:table-cell">
-                  <%= Timex.format!(email_alias.inserted_at, "{ISOdate}") %>
+                  {Timex.format!(email_alias.inserted_at, "{ISOdate}")}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                   <.link


### PR DESCRIPTION
## Summary

Audited every source file in `lib/` and `assets/js/` against the project's `AGENTS.md` guidelines (one reviewer per file) and applied **safe, behavior-preserving** conformance fixes across 16 files.

- **HEEx interpolation** — use `{...}` for plain value interpolation in tag bodies; `<%= %>` kept only for block constructs (`if`/`cond`/`case`/`for`).
- **HEEx comments** — `<!-- -->` → `<%!-- --%>` so they don't leak into rendered output (navbar, signup).
- **Forms** — added unique DOM `id`s for testability; removed an unused `<.form :let={_f}>` binding.
- **Tailwind** — conditional classes moved to `class={[...]}` list syntax (appearance settings).
- **`proxy.ex`** — removed a dead duplicate expression.

> Note: the password-reset form-action bug found during this audit is split into its own PR (#148).

## Testing
- `mix compile --warnings-as-errors` ✅
- Full suite passes ✅
- `mix format` clean ✅

## Out of scope
The audit also surfaced higher-risk items left for follow-up (they require cross-file changes or alter behavior): the legacy `<.form :let={f} for={@changeset}>` + `Phoenix.HTML` helper pattern across `user_*` templates, missing `handle_event` fallback branches in a couple of LiveViews, Ecto `cast/3` mass-assignment of FK fields, and LiveView stream adoption for collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)