### PR TITLE
fix: interpolate token in password reset form action

### DIFF
--- a/lib/shroud_web/controllers/user_reset_password_html/edit.html.heex
+++ b/lib/shroud_web/controllers/user_reset_password_html/edit.html.heex
@@ -11,7 +11,7 @@
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
     <div class="bg-white dark:bg-gray-800 py-8 px-4 shadow-sm dark:shadow-gray-900/50 sm:rounded-lg sm:px-10">
-      <.form :let={f} for={@changeset} action={~p"/users/reset_password/@token"} class="space-y-6">
+      <.form :let={f} for={@changeset} id="reset-password-form" action={~p"/users/reset_password/#{@token}"} class="space-y-6">
         <div>
           <%= label f, :password, "New password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
           <div class="mt-1">

--- a/test/shroud_web/controllers/user_reset_password_controller_test.exs
+++ b/test/shroud_web/controllers/user_reset_password_controller_test.exs
@@ -57,6 +57,14 @@ defmodule ShroudWeb.UserResetPasswordControllerTest do
       assert html_response(conn, 200) =~ "Reset password"
     end
 
+    test "form posts to the token URL", %{conn: conn, token: token} do
+      conn = get(conn, ~p"/users/reset_password/#{token}")
+      response = html_response(conn, 200)
+
+      assert response =~ ~s(action="/users/reset_password/#{token}")
+      refute response =~ "/users/reset_password/@token"
+    end
+
     test "does not render reset password with invalid token", %{conn: conn} do
       conn = get(conn, ~p"/users/reset_password/oops")
       assert redirected_to(conn) == "/"


### PR DESCRIPTION
## Bug

The password reset form posted to the **literal** path `/users/reset_password/@token` instead of interpolating the token (`#{@token}`):

```heex
<.form :let={f} for={@changeset} action={~p"/users/reset_password/@token"} ...>
```

The `put "/users/reset_password/:token"` route therefore received the literal string `"@token"` as the token, so resetting a password through this form failed.

## Fix

Interpolate the token into the action (`~p"/users/reset_password/#{@token}"`), matching the sibling confirmation form. Also adds an `id` to the form.

## Test

Added a regression test that renders `GET /users/reset_password/:token` and asserts the form `action` points at the real token URL (and not the literal `@token`). Verified it **fails before** the fix and **passes after**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

