### PR TITLE
fix: always return noreply from delete/block_sender handle_event

### DIFF
--- a/lib/shroud_web/live/custom_domain_live/show.ex
+++ b/lib/shroud_web/live/custom_domain_live/show.ex
@@ -124,16 +124,18 @@ defmodule ShroudWeb.CustomDomainLive.Show do
   end
 
   def handle_event("delete", _value, %{assigns: %{current_user: user, domain: domain}} = socket) do
-    if user |> can?(destroy(domain)) do
-      Domain.delete_custom_domain!(domain)
+    socket =
+      if user |> can?(destroy(domain)) do
+        Domain.delete_custom_domain!(domain)
 
-      socket =
         socket
         |> put_flash(:success, "Deleted #{domain.domain}.")
         |> redirect(to: ~p"/domains")
+      else
+        socket |> put_flash(:error, "You don't have permission to do that.")
+      end
 
-      {:noreply, socket}
-    end
+    {:noreply, socket}
   end
 
   def handle_info(:dns_check_complete, socket) do

--- a/lib/shroud_web/live/spam_email_live/index.ex
+++ b/lib/shroud_web/live/spam_email_live/index.ex
@@ -35,12 +35,21 @@ defmodule ShroudWeb.SpamEmailLive.Index do
   def handle_event("block_sender", %{"sender" => sender, "alias" => alias_address}, socket) do
     email_alias = Aliases.get_email_alias_by_address!(alias_address)
 
-    if can?(socket.assigns.current_user, update(email_alias)) do
-      with {:ok, _alias} <- Aliases.block_sender(email_alias, sender) do
-        # re-load spam emails to update associated email_alias' list of blocked senders
-        {:noreply, load_spam_emails(socket)}
+    socket =
+      if can?(socket.assigns.current_user, update(email_alias)) do
+        case Aliases.block_sender(email_alias, sender) do
+          {:ok, _alias} ->
+            # re-load spam emails to update associated email_alias' list of blocked senders
+            load_spam_emails(socket)
+
+          {:error, _changeset} ->
+            put_flash(socket, :error, "Something went wrong.")
+        end
+      else
+        put_flash(socket, :error, "You don't have permission to do that.")
       end
-    end
+
+    {:noreply, socket}
   end
 
   defp load_spam_emails(socket) do

--- a/test/shroud_web/live/custom_domain_live/show_test.exs
+++ b/test/shroud_web/live/custom_domain_live/show_test.exs
@@ -1,0 +1,38 @@
+defmodule ShroudWeb.CustomDomainLive.ShowTest do
+  use ShroudWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Shroud.DomainFixtures
+
+  alias Shroud.Domain
+
+  describe "Show" do
+    setup :register_and_log_in_user
+
+    setup %{user: user} do
+      %{
+        domain: custom_domain_fixture(%{user_id: user.id})
+      }
+    end
+
+    test "renders the domain", %{conn: conn, domain: domain} do
+      {:ok, _view, html} = live(conn, ~p"/domains/#{domain.domain}")
+
+      assert html =~ domain.domain
+    end
+
+    test "deletes the domain", %{conn: conn, user: user, domain: domain} do
+      {:ok, view, _html} = live(conn, ~p"/domains/#{domain.domain}")
+
+      view
+      |> element("form[phx-submit='delete']")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/domains")
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Domain.get_custom_domain!(user, domain.domain)
+      end
+    end
+  end
+end

--- a/test/shroud_web/live/spam_email_live_test.exs
+++ b/test/shroud_web/live/spam_email_live_test.exs
@@ -1,0 +1,60 @@
+defmodule ShroudWeb.SpamEmailLiveTest do
+  use ShroudWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Shroud.EmailFixtures
+  import Shroud.AliasesFixtures
+
+  alias Shroud.Aliases
+
+  describe "Index" do
+    setup :register_and_log_in_user
+
+    setup %{user: user} do
+      email_alias = alias_fixture(%{user_id: user.id})
+
+      %{
+        email_alias: email_alias,
+        spam_email: spam_email_fixture(%{}, user, email_alias)
+      }
+    end
+
+    test "lists spam emails", %{conn: conn, spam_email: spam_email} do
+      {:ok, _view, html} = live(conn, ~p"/detention")
+
+      assert html =~ "Spam"
+      assert html =~ spam_email.subject
+    end
+
+    test "blocks a sender", %{conn: conn, spam_email: spam_email, email_alias: email_alias} do
+      {:ok, view, _html} = live(conn, ~p"/detention")
+
+      html =
+        view
+        |> element("button[phx-value-sender='#{spam_email.from}']")
+        |> render_click()
+
+      assert html =~ "Going forward, this alias will block emails from this sender."
+
+      reloaded = Aliases.get_email_alias_by_address!(email_alias.address)
+      assert spam_email.from in reloaded.blocked_addresses
+    end
+
+    test "shows an error flash when blocking the sender fails", %{conn: conn, user: user} do
+      # A sender without an @ sign fails the blocked_addresses changeset, so
+      # block_sender/2 returns {:error, _}. The LiveView must still return a
+      # noreply (rather than crashing) and surface an error.
+      spam_email = spam_email_fixture(%{from: "invalid sender"}, user)
+
+      {:ok, view, _html} = live(conn, ~p"/detention")
+
+      html =
+        view
+        |> element("button[phx-value-sender='#{spam_email.from}']")
+        |> render_click()
+
+      assert html =~ "Something went wrong."
+      assert has_element?(view, "button[phx-value-sender='#{spam_email.from}']")
+    end
+  end
+end


### PR DESCRIPTION
## Bug

Two `handle_event` clauses could return `nil` instead of `{:noreply, socket}`, which crashes the LiveView:

- **`custom_domain_live/show.ex` `"delete"`** — `if can?(...)` had no `else`, so an unauthorized event fell through to `nil`.
- **`spam_email_live/index.ex` `"block_sender"`** — only the authorized `{:ok, _}` path returned a noreply; an unauthorized user or an `{:error, _}` from `block_sender/2` fell through.

## Fix

Every path now returns `{:noreply, socket}`, with an error flash on the unauthorized/failure cases.

- The custom-domain unauthorized branch is defensive: `mount` already scopes the domain to `current_user` via `get_custom_domain!/2`, so a non-owner can't reach the view.
- The spam `block_sender` `{:error, _}` path is reachable (e.g. an invalid sender address fails the `blocked_addresses` changeset) and is now covered by a test.

## Tests

New LiveView tests for both views, including the `block_sender` failure path asserting an error flash + no crash.

`POSTGRES_PORT=… mix test test/shroud_web/live/custom_domain_live/show_test.exs test/shroud_web/live/spam_email_live_test.exs` → 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

