### PR TITLE
fix: rebind socket so custom alias success flash is shown

### DIFF
--- a/lib/shroud_web/live/email_alias_live/index.ex
+++ b/lib/shroud_web/live/email_alias_live/index.ex
@@ -81,9 +81,10 @@ defmodule ShroudWeb.EmailAliasLive.Index do
     if user |> can?(create(EmailAlias)) do
       case Aliases.create_email_alias(%{user_id: user.id, address: address}) do
         {:ok, email_alias} ->
-          socket
-          |> put_flash(:success, "Created new alias #{email_alias.address}.")
-          |> assign(:aliases, [email_alias | socket.assigns.aliases])
+          socket =
+            socket
+            |> put_flash(:success, "Created new alias #{email_alias.address}.")
+            |> assign(:aliases, [email_alias | socket.assigns.aliases])
 
           {:noreply,
            push_navigate(socket,

--- a/test/shroud_web/live/email_alias_live_test.exs
+++ b/test/shroud_web/live/email_alias_live_test.exs
@@ -3,6 +3,7 @@ defmodule ShroudWeb.EmailAliasLiveTest do
 
   import Phoenix.LiveViewTest
   import Shroud.AliasesFixtures
+  import Shroud.DomainFixtures
 
   describe "Index" do
     setup :register_and_log_in_user
@@ -32,6 +33,27 @@ defmodule ShroudWeb.EmailAliasLiveTest do
 
       assert html =~ "Created new alias"
       assert html =~ "@email.shroud.test"
+    end
+
+    test "creates new custom alias", %{conn: conn, user: user} do
+      custom_domain = custom_domain_fixture(%{user_id: user.id})
+
+      {:ok, index_live, _html} =
+        conn
+        |> live(~p"/")
+
+      # open the custom alias modal, which sets the domain to create the alias under
+      index_live
+      |> render_hook("open_custom_alias_modal", %{"text" => "@#{custom_domain.domain}"})
+
+      {:ok, _view, html} =
+        index_live
+        |> form("form[phx-submit='create_custom_alias']", %{"alias_name" => "john.doe"})
+        |> render_submit()
+        |> follow_redirect(conn)
+
+      assert html =~ "Created new alias"
+      assert html =~ "john.doe@#{custom_domain.domain}"
     end
 
     # test "deletes email_alias in listing", %{conn: conn, email_alias: email_alias} do


### PR DESCRIPTION
## Bug

The `create_custom_alias` handler in `email_alias_live/index.ex` piped `socket` through `put_flash/2` and `assign/3` but **discarded the result** (missing `socket =`), then called `push_navigate/2` on the original socket. The success flash ("Created new alias …") and the updated `:aliases` assign were silently lost.

## Fix

Rebind the socket so the flash/assign take effect before navigating — matching the sibling `add_alias` handler.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

