### PR TITLE
fix: return error when lifetime code redemption transaction fails

### DIFF
--- a/lib/shroud/billing.ex
+++ b/lib/shroud/billing.ex
@@ -15,7 +15,10 @@ defmodule Shroud.Billing do
   end
 
   @spec redeem_lifetime_code(String.t(), User) ::
-          :ok | {:error, :invalid_code} | {:error, :already_redeemed}
+          :ok
+          | {:error, :invalid_code}
+          | {:error, :already_redeemed}
+          | {:error, :redemption_failed}
   def redeem_lifetime_code(code, %User{} = user) do
     cond do
       not valid_code?(code) ->
@@ -25,20 +28,26 @@ defmodule Shroud.Billing do
         {:error, :already_redeemed}
 
       true ->
-        Multi.new()
-        |> Multi.insert(
-          :lifetime_code,
-          LifetimeCode.changeset(%LifetimeCode{}, %{code: code, redeemed_by_id: user.id})
-        )
-        |> Multi.update(
-          :user,
-          User.status_changeset(user, %{status: :lifetime})
-        )
-        |> Repo.transaction()
+        result =
+          Multi.new()
+          |> Multi.insert(
+            :lifetime_code,
+            LifetimeCode.changeset(%LifetimeCode{}, %{code: code, redeemed_by_id: user.id})
+          )
+          |> Multi.update(
+            :user,
+            User.status_changeset(user, %{status: :lifetime})
+          )
+          |> Repo.transaction()
 
-        Logger.notice("#{user.email} redeemed a lifetime code!")
+        case result do
+          {:ok, _changes} ->
+            Logger.notice("#{user.email} redeemed a lifetime code!")
+            :ok
 
-        :ok
+          {:error, _failed_operation, _failed_value, _changes_so_far} ->
+            {:error, :redemption_failed}
+        end
     end
   end
 

--- a/test/shroud_web/controllers/user_settings_controller_test.exs
+++ b/test/shroud_web/controllers/user_settings_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ShroudWeb.UserSettingsControllerTest do
   use ShroudWeb.ConnCase, async: true
 
-  alias Shroud.Accounts
+  alias Shroud.{Accounts, Billing, Repo}
   import Shroud.AccountsFixtures
 
   setup :register_and_log_in_user
@@ -17,6 +17,25 @@ defmodule ShroudWeb.UserSettingsControllerTest do
       conn = build_conn()
       conn = get(conn, ~p"/settings/account")
       assert redirected_to(conn) == ~p"/users/log_in"
+    end
+  end
+
+  describe "POST /settings/billing/lifetime" do
+    test "redeems a lifetime code through the settings form", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/settings/billing/lifetime")
+      assert html_response(conn, 200) =~ "Sign up for a lifetime account"
+
+      code = Billing.create_lifetime_code()
+      conn = post(conn, ~p"/settings/billing/lifetime", %{"lifetime_code" => code})
+
+      assert redirected_to(conn) == ~p"/settings/billing"
+
+      assert Flash.get(conn.assigns.flash, :info) ==
+               "You have successfully signed up for lifetime access!"
+
+      conn = get(recycle(conn), ~p"/settings/billing")
+      assert html_response(conn, 200) =~ "You're on a lifetime plan"
+      assert Repo.reload!(user).status == :lifetime
     end
   end
 


### PR DESCRIPTION
just a small improvement -- let's handle the case where the lifetime-code-redemption DB transaction fails for any reason.