### PR TITLE
fix: return 403 instead of 500 for a malformed API bearer token

### DIFF
--- a/lib/shroud_web/controllers/user_api_auth.ex
+++ b/lib/shroud_web/controllers/user_api_auth.ex
@@ -38,8 +38,12 @@ defmodule ShroudWeb.UserApiAuth do
       [header_value] ->
         case Regex.named_captures(~r/Bearer (?<token>[^\s]+)/i, header_value) do
           %{"token" => token} ->
-            {:ok, token} = Base.decode64(token)
-            {token, conn}
+            # A malformed (non-base64) token is treated like a missing token
+            # rather than raising a MatchError (which would surface as a 500).
+            case Base.decode64(token) do
+              {:ok, decoded_token} -> {decoded_token, conn}
+              :error -> {nil, conn}
+            end
 
           _ ->
             {nil, conn}

--- a/test/shroud_web/controllers/api/v1/domain_controller_test.exs
+++ b/test/shroud_web/controllers/api/v1/domain_controller_test.exs
@@ -48,6 +48,15 @@ defmodule ShroudWeb.Api.V1.DomainControllerTest do
 
       assert length(json_response(conn, 200)["domains"]) == 1
     end
+
+    test "returns 403 (not 500) for a malformed, non-base64 bearer token", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer not-valid-base64!!")
+        |> get(~p"/api/v1/domains")
+
+      assert json_response(conn, 403) == %{"error" => "Invalid token"}
+    end
   end
 
   defp authorized_get(conn, user, path, params \\ nil) do


### PR DESCRIPTION
## Bug

`UserApiAuth.ensure_api_token/1` decoded the bearer token with a hard match:

```elixir
{:ok, token} = Base.decode64(token)
```

If a client sent an `Authorization: Bearer <token>` whose token isn't valid base64, this raised a `MatchError`, surfacing as an HTTP **500** instead of a clean auth rejection.

## Fix

Use a `case` on `Base.decode64/1` and treat a decode failure like a missing/invalid token (`{nil, conn}`), so the request flows to the existing **403 "Invalid token"** response.

## Test

Added a controller test posting a non-base64 bearer token and asserting `403 {"error": "Invalid token"}`. On `main` this raises a `MatchError` (500).

`POSTGRES_PORT=… mix test test/shroud_web/controllers/api/v1/domain_controller_test.exs` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

