### PR TITLE
chore: standardize on AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This repo contains our source code. If you just want to set up your email aliase
 Shroud is built with Elixir and [Phoenix](https://www.phoenixframework.org/). Make sure you
 have Elixir and mix installed.
 
+Our agent guidelines live in [`AGENTS.md`](AGENTS.md). If you use Claude Code, install
+something like the [agents-md-loader](https://tangled.org/btao.org/claude-agents-md-loader)
+so that Claude Code reads `AGENTS.md` files (it does not pick them up natively).
+
 To start the server:
 
   * Install dependencies with `mix deps.get`


### PR DESCRIPTION
## Summary

I find it annoying that Claude Code refuses to support AGENTS.md files, forcing us to clutter our repo with CLAUDE.md files that symlink elsewhere.

Instead, let's just use AGENTS.md files, and tell Claude Code users to install a plugin to handle those. (I am a Claude Code user so I'll feel the impacts of this first-hand!)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

