### PR TITLE
refactor: use LiveView streams for aliases/failed-job lists

### DIFF
--- a/lib/shroud_web/live/debug_emails/index.ex
+++ b/lib/shroud_web/live/debug_emails/index.ex
@@ -49,34 +49,32 @@ defmodule ShroudWeb.DebugEmailsLive.Index do
                 </th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-200 bg-white">
-              <%= for job <- @failed_jobs do %>
-                <tr>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {job.args["from"]}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {job.args["to"]}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {job.attempt} / {job.max_attempts}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {Timex.format!(job.inserted_at, "{ISOdate} {h24}:{m}")}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {Timex.format!(job.scheduled_at, "{ISOdate} {h24}:{m}")}
-                  </td>
-                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                    <a
-                      href={~p"/debug_emails/#{job.id}"}
-                      class="text-indigo-600 hover:text-indigo-900"
-                    >
-                      Details
-                    </a>
-                  </td>
-                </tr>
-              <% end %>
+            <tbody id="failed-jobs" phx-update="stream" class="divide-y divide-gray-200 bg-white">
+              <tr :for={{id, job} <- @streams.failed_jobs} id={id}>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {job.args["from"]}
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {job.args["to"]}
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {job.attempt} / {job.max_attempts}
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {Timex.format!(job.inserted_at, "{ISOdate} {h24}:{m}")}
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {Timex.format!(job.scheduled_at, "{ISOdate} {h24}:{m}")}
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <a
+                    href={~p"/debug_emails/#{job.id}"}
+                    class="text-indigo-600 hover:text-indigo-900"
+                  >
+                    Details
+                  </a>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -95,9 +93,9 @@ defmodule ShroudWeb.DebugEmailsLive.Index do
 
       failed_jobs = Repo.all(query)
 
-      assign(socket, :failed_jobs, failed_jobs)
+      stream(socket, :failed_jobs, failed_jobs)
     else
-      assign(socket, :failed_jobs, [])
+      stream(socket, :failed_jobs, [])
     end
   end
 end

--- a/lib/shroud_web/live/email_alias_live/index.ex
+++ b/lib/shroud_web/live/email_alias_live/index.ex
@@ -42,7 +42,6 @@ defmodule ShroudWeb.EmailAliasLive.Index do
           socket =
             socket
             |> put_flash(:success, "Created new alias #{email_alias.address}.")
-            |> assign(:aliases, [email_alias | socket.assigns.aliases])
 
           {:noreply,
            push_navigate(socket,
@@ -84,7 +83,6 @@ defmodule ShroudWeb.EmailAliasLive.Index do
           socket =
             socket
             |> put_flash(:success, "Created new alias #{email_alias.address}.")
-            |> assign(:aliases, [email_alias | socket.assigns.aliases])
 
           {:noreply,
            push_navigate(socket,
@@ -141,11 +139,12 @@ defmodule ShroudWeb.EmailAliasLive.Index do
   end
 
   defp update_email_aliases(socket) do
-    assign(
-      socket,
-      :aliases,
+    aliases =
       Aliases.list_aliases(socket.assigns[:current_user], socket.assigns[:filter_query])
-    )
+
+    socket
+    |> stream(:aliases, aliases, reset: true)
+    |> assign(:filtered_alias_count, length(aliases))
   end
 
   defp assign_at_free_limit(socket) do

--- a/lib/shroud_web/live/email_alias_live/index.html.heex
+++ b/lib/shroud_web/live/email_alias_live/index.html.heex
@@ -5,7 +5,8 @@
   icon={:information_circle}
 >
   You're on the free plan ({@alias_count}/5 aliases used).
-  <.link href={~p"/settings/billing"} class="underline font-medium">Upgrade</.link> for unlimited aliases, custom domains, and outgoing email.
+  <.link href={~p"/settings/billing"} class="underline font-medium">Upgrade</.link>
+  for unlimited aliases, custom domains, and outgoing email.
 </.alert>
 
 <form phx-submit="create_custom_alias">
@@ -31,8 +32,7 @@
   </.live_component>
 </form>
 
-<%= if Enum.empty?(@aliases) and @filter_query == "" do %>
-
+<%= if @filtered_alias_count == 0 and @filter_query == "" do %>
   <.empty_state
     title="No aliases yet"
     description="Get started by adding your first alias."
@@ -49,8 +49,8 @@
 <% else %>
   <div class="mb-3 flex items-center justify-between">
     <div class="text-gray-600 dark:text-gray-400 text-sm hidden sm:block">
-      {length(@aliases)}
-      <%= if length(@aliases) == 1 do %>
+      {@filtered_alias_count}
+      <%= if @filtered_alias_count == 1 do %>
         alias
       <% else %>
         aliases
@@ -83,7 +83,12 @@
         <% else %>
           <.button_with_dropdown click="add_alias" text="New alias" icon={:plus}>
             <.dropdown_item index={0} click="add_alias" text={"@#{Util.email_domain()}"} />
-            <.dropdown_item :for={{domain, index} <- Enum.with_index(@custom_domains, 1)} index={index} click="open_custom_alias_modal" text={"@#{domain.domain}"} />
+            <.dropdown_item
+              :for={{domain, index} <- Enum.with_index(@custom_domains, 1)}
+              index={index}
+              click="open_custom_alias_modal"
+              text={"@#{domain.domain}"}
+            />
           </.button_with_dropdown>
         <% end %>
       <% end %>
@@ -125,8 +130,12 @@
                 </th>
               </tr>
             </thead>
-            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-              <tr :for={email_alias <- @aliases}>
+            <tbody
+              id="aliases"
+              phx-update="stream"
+              class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"
+            >
+              <tr :for={{id, email_alias} <- @streams.aliases} id={id}>
                 <td class="px-6 py-4 whitespace-nowrap">
                   <div>
                     <dl class="text-sm lg:hidden">
@@ -143,7 +152,10 @@
                         <% end %>
                       </dd>
                     </dl>
-                    <.link navigate={~p"/alias/#{email_alias.address}"} class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-500 dark:hover:text-gray-400">
+                    <.link
+                      navigate={~p"/alias/#{email_alias.address}"}
+                      class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-500 dark:hover:text-gray-400"
+                    >
                       {email_alias.address}
                     </.link>
                     <div class="text-sm text-gray-500 dark:text-gray-400">
@@ -151,13 +163,19 @@
                     </div>
                     <dl class="text-sm lg:hidden">
                       <dt class="sr-only sm:hidden">Forwarded</dt>
-                      <dd class="mt-1 truncate text-gray-500 dark:text-gray-400 sm:hidden">{email_alias.forwarded} forwarded</dd>
+                      <dd class="mt-1 truncate text-gray-500 dark:text-gray-400 sm:hidden">
+                        {email_alias.forwarded} forwarded
+                      </dd>
                     </dl>
                   </div>
                 </td>
                 <td class="hidden px-6 py-4 whitespace-nowrap sm:table-cell">
-                  <div class="text-sm text-gray-900 dark:text-gray-100">{email_alias.forwarded}</div>
-                  <div class="text-sm text-gray-500 dark:text-gray-400">{email_alias.forwarded_in_last_30_days} in the last month</div>
+                  <div class="text-sm text-gray-900 dark:text-gray-100">
+                    {email_alias.forwarded}
+                  </div>
+                  <div class="text-sm text-gray-500 dark:text-gray-400">
+                    {email_alias.forwarded_in_last_30_days} in the last month
+                  </div>
                 </td>
                 <td class="hidden px-6 py-4 whitespace-nowrap lg:table-cell">
                   <%= if email_alias.enabled do %>

--- a/test/shroud_web/live/custom_domain_live/index_test.exs
+++ b/test/shroud_web/live/custom_domain_live/index_test.exs
@@ -1,0 +1,16 @@
+defmodule ShroudWeb.CustomDomainLive.IndexTest do
+  use ShroudWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "Index" do
+    setup :register_and_log_in_user
+
+    test "shows the empty state when the user has no domains", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/domains")
+
+      refute has_element?(view, "#domains")
+      assert has_element?(view, "button", "Add domain")
+    end
+  end
+end


### PR DESCRIPTION
This converts a few tables to use [liveview streams](https://phoenix-live-view.hexdocs.pm/Phoenix.LiveView.html#stream/4) for better performance if there's lots of data.