### PR TITLE
fix: strip XML processing instructions in SpamEmailScrubber

### DIFF
--- a/lib/shroud/email/spam_email_scrubber.ex
+++ b/lib/shroud/email/spam_email_scrubber.ex
@@ -17,6 +17,11 @@ defmodule Shroud.Email.SpamEmailScrubber do
 
   Meta.strip_comments()
 
+  # Strip XML processing instructions (<?xml:namespace ...?>). The generated
+  # catch-all only matches binary tag names, so atom-tagged `{:pi, _, _}` nodes
+  # would otherwise raise FunctionClauseError on real-world spam HTML.
+  def scrub({:pi, _name, _content}), do: ""
+
   Meta.allow_tag_with_uri_attributes("a", ["href"], @valid_schemes)
   Meta.allow_tag_with_these_attributes("a", ["name", "title"])
 

--- a/test/shroud/email/spam_email_scrubber_test.exs
+++ b/test/shroud/email/spam_email_scrubber_test.exs
@@ -1,0 +1,22 @@
+defmodule Shroud.Email.SpamEmailScrubberTest do
+  use ExUnit.Case, async: true
+
+  alias Shroud.Email.SpamEmailScrubber
+
+  describe "scrub/1" do
+    test "strips XML processing instructions without crashing" do
+      # Real-world spam email containing an `<?xml:namespace ...?>` processing
+      # instruction. Previously this raised FunctionClauseError because the
+      # generated catch-all only matched binary tag names, not the `:pi` atom.
+      html =
+        ~S(<html><body><p>hi</p><?xml:namespace prefix="o" ns="urn:schemas-microsoft-com:office:office"?></body></html>)
+
+      assert HtmlSanitizeEx.Scrubber.scrub(html, SpamEmailScrubber) == "<p>hi</p>"
+    end
+
+    test "preserves allowed tags" do
+      assert HtmlSanitizeEx.Scrubber.scrub(~S(<p>hello <b>world</b></p>), SpamEmailScrubber) ==
+               "<p>hello <b>world</b></p>"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a production `FunctionClauseError` in `Shroud.Email.SpamEmailScrubber.scrub/1` triggered by spam emails containing `<?xml:namespace ...?>` processing instructions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

