### PR TITLE
fix: prevent ArgumentError when DISABLE_SIGNUPS env var is unset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ node_modules/
 # Ignore generated js hook files for components
 assets/js/_hooks/
 assets/css/_components.css
+
+# Local git worktrees
+.worktrees/

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -139,7 +139,7 @@ if config_env() == :prod do
   config :shroud,
     notifier_webhook_url: System.get_env("NOTIFIER_WEBHOOK_URL"),
     admin_user_email: System.get_env("ADMIN_EMAIL"),
-    disable_signups: System.get_env("DISABLE_SIGNUPS"),
+    disable_signups: System.get_env("DISABLE_SIGNUPS") in ~w(true 1 yes),
     app_domain: app_domain,
     email_domain: email_domain,
     env: :prod

--- a/lib/shroud/accounts.ex
+++ b/lib/shroud/accounts.ex
@@ -94,7 +94,7 @@ defmodule Shroud.Accounts do
 
   """
   def register_user(attrs) do
-    if not Application.fetch_env!(:shroud, :disable_signups) do
+    if Application.fetch_env!(:shroud, :disable_signups) not in [true, "true", "1", "yes"] do
       case %User{}
            |> User.registration_changeset(attrs)
            |> Repo.insert(returning: true) do

--- a/test/shroud/accounts_test.exs
+++ b/test/shroud/accounts_test.exs
@@ -121,6 +121,16 @@ defmodule Shroud.AccountsTest do
 
       assert_enqueued(worker: Shroud.NotifierJob)
     end
+
+    test "does not crash when disable_signups is unset (nil)" do
+      prev = Application.get_env(:shroud, :disable_signups)
+      Application.put_env(:shroud, :disable_signups, nil)
+      on_exit(fn -> Application.put_env(:shroud, :disable_signups, prev) end)
+
+      email = unique_user_email()
+      assert {:ok, user} = Accounts.register_user(valid_user_attributes(email: email))
+      assert user.email == email
+    end
   end
 
   describe "change_user_registration/2" do


### PR DESCRIPTION
## Summary

Before, every signup attempt raised `ArgumentError: argument error` at `lib/shroud/accounts.ex:97` when DISABLE_SIGNUPS was unset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

