### PR TITLE
fix: handle proxy network errors

### DIFF
--- a/lib/shroud/proxy.ex
+++ b/lib/shroud/proxy.ex
@@ -2,7 +2,11 @@ defmodule Shroud.Proxy do
   require Logger
 
   @type proxy_error ::
-          :invalid_uri | :non_200_status_code | :too_many_redirects | :not_an_image | any
+          :invalid_uri
+          | :network_error
+          | :non_200_status_code
+          | :too_many_redirects
+          | :not_an_image
 
   @spec get(String.t()) :: {:ok, {any, String.t()}} | {:error, proxy_error}
   def get(url) do
@@ -47,9 +51,9 @@ defmodule Shroud.Proxy do
         Logger.notice("Attempt to proxy \"#{url}\" failed; returned status code #{status_code}")
         {:error, :non_200_status_code}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.warning("Could not fetch #{url}: #{reason}")
-        {:error, reason}
+      {:error, %HTTPoison.Error{} = error} ->
+        Logger.warning("Could not fetch #{url}: #{Exception.message(error)}")
+        {:error, :network_error}
     end
   end
 

--- a/test/shroud/proxy_test.exs
+++ b/test/shroud/proxy_test.exs
@@ -1,6 +1,7 @@
 defmodule Shroud.ProxyTest do
   use Shroud.DataCase, async: true
   use Oban.Testing, repo: Shroud.Repo
+  import ExUnit.CaptureLog
   import Mox
   alias Shroud.Proxy
 
@@ -127,6 +128,23 @@ defmodule Shroud.ProxyTest do
       end)
 
       assert {:ok, {image_body(), nil}} == Proxy.get(url)
+    end
+
+    test "normalizes network errors with non-string reasons" do
+      url = "https://example.com/foo.png"
+      reason = {:tls_alert, {:handshake_failure, ~c"TLS client received a fatal alert"}}
+
+      Shroud.MockHTTPoison
+      |> expect(:get, fn ^url ->
+        {:error, %HTTPoison.Error{reason: reason}}
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :network_error} == Proxy.get(url)
+        end)
+
+      assert log =~ inspect(reason)
     end
   end
 

--- a/test/shroud_web/controllers/proxy_controller_test.exs
+++ b/test/shroud_web/controllers/proxy_controller_test.exs
@@ -63,6 +63,20 @@ defmodule ShroudWeb.ProxyControllerTest do
 
       assert response_content_type(conn, :png)
     end
+
+    test "returns an error response when the upstream TLS handshake fails", %{conn: conn} do
+      url = "https://example.com/foo.png"
+      reason = {:tls_alert, {:handshake_failure, ~c"TLS client received a fatal alert"}}
+
+      Shroud.MockHTTPoison
+      |> expect(:get, fn ^url ->
+        {:error, %HTTPoison.Error{reason: reason}}
+      end)
+
+      conn = get(conn, ~p"/proxy", %{"url" => url})
+
+      assert response(conn, 500) == "Error: network_error"
+    end
   end
 
   defp image_body do


### PR DESCRIPTION
## Summary

- safely format arbitrary `HTTPoison.Error` reasons when proxy requests fail
- normalize upstream transport failures to `:network_error` instead of exposing arbitrary error terms
- add unit and controller regressions for TLS handshake alert tuples

Fixes Sentry issue SHROUDEMAIL-5A (7305324053).

## Verification

- `mix test` — 454 passed
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix credo --strict lib/shroud/proxy.ex test/shroud/proxy_test.exs test/shroud_web/controllers/proxy_controller_test.exs`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

