### PR TITLE
feat: add Cap for bot prevention

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,9 +22,6 @@ import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
 import "../vendor/components";
-// Cap CAPTCHA widget — self-registers the <cap-widget> custom element as a
-// side effect. Bundled (not CDN-loaded) per the "never use external CDNs"
-// rule; version is pinned in assets/package.json.
 import "@cap.js/widget";
 import { Modal, Notification } from "./hooks";
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,10 @@ import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
 import "../vendor/components";
+// Cap CAPTCHA widget — self-registers the <cap-widget> custom element as a
+// side effect. Bundled (not CDN-loaded) per the "never use external CDNs"
+// rule; version is pinned in assets/package.json.
+import "@cap.js/widget";
 import { Modal, Notification } from "./hooks";
 
 import { initTheme, setTheme } from "./theme";

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,9 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
+        "@cap.js/widget": "0.1.56",
         "@ryangjchandler/alpine-tooltip": "^2.0.1",
         "alpinejs": "^3.15.11"
       }
+    },
+    "node_modules/@cap.js/widget": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@cap.js/widget/-/widget-0.1.56.tgz",
+      "integrity": "sha512-j640dNNNIF8IWmwqmSx0ihgU8sz/6Jm9mHveeDWUk8aXVqFm+2TSsp5bawtMtgf0aa7rFkmT9p76jrqO1uSEpQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@cap.js/widget": "0.1.56",
     "@ryangjchandler/alpine-tooltip": "^2.0.1",
     "alpinejs": "^3.15.11"
   }

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,6 +12,16 @@ config :shroud,
   chatwoot_base_url: System.get_env("CHATWOOT_BASE_URL"),
   chatwoot_hmac_token: System.get_env("CHATWOOT_HMAC_TOKEN")
 
+# Optional: Cap CAPTCHA. Set all three of CAP_INSTANCE_URL, CAP_SITE_KEY,
+# and CAP_SECRET_KEY to enable. When any is unset, Cap is fully disabled
+# (no widget rendered, no verification performed). The instance URL is
+# the Cap Standalone base, e.g. http://cap:3000 (in compose) or
+# https://cap.yourdomain.com.
+config :shroud,
+  cap_instance_url: System.get_env("CAP_INSTANCE_URL"),
+  cap_site_key: System.get_env("CAP_SITE_KEY"),
+  cap_secret_key: System.get_env("CAP_SECRET_KEY")
+
 config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET")
 
 # In the test env, billing config (incl. a fixed webhook secret) comes from

--- a/config/test.exs
+++ b/config/test.exs
@@ -61,3 +61,8 @@ config :shroud,
 
 # Used by the Stripe webhook controller to verify signatures in tests.
 config :shroud, :billing, stripe_webhook_secret: "whsec_test_secret_123"
+
+# Route Cap verification requests through the Req.Test stub (named
+# Shroud.Captcha) so captcha_test.exs can assert on responses without any
+# real network calls.
+config :shroud, :cap_req_options, plug: {Req.Test, Shroud.Captcha}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,23 @@ services:
     ports:
       - "5432:5432"
 
+  cap:
+    image: tiago2/cap:latest
+    restart: unless-stopped
+    depends_on:
+      - valkey
+    ports:
+      - "3000:3000"
+    environment:
+      - ADMIN_KEY=${CAP_ADMIN_KEY}
+      - REDIS_URL=redis://valkey:6379
+
+  valkey:
+    image: valkey/valkey:9-alpine
+    restart: unless-stopped
+    command: valkey-server --save 60 1 --loglevel warning --maxmemory-policy noeviction
+    volumes:
+      - valkey_data:/data
+
+volumes:
+  valkey_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "5432:5432"
 
   cap:
-    image: tiago2/cap:latest
+    image: tiago2/cap:3
     restart: unless-stopped
     depends_on:
       - valkey

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
   valkey:
     image: valkey/valkey:9-alpine
     restart: unless-stopped
-    command: valkey-server --save 60 1 --loglevel warning --maxmemory-policy noeviction
+    command: valkey-server --save 60 1 --loglevel warning --maxmemory 256mb --maxmemory-policy noeviction
     volumes:
       - valkey_data:/data
 

--- a/example.env
+++ b/example.env
@@ -30,6 +30,9 @@ S3_HOST=abc
 # Cap CAPTCHA (optional). Set all three to enable Cap on the signup,
 # login, and password-reset forms. Leave unset to disable (forms work
 # without Cap). See docker-compose.yaml for the cap + valkey services.
-CAP_INSTANCE_URL=
+# CAP_ADMIN_KEY: required by the `cap` docker service at boot (dashboard
+# password). Generate with: openssl rand -hex 32
+CAP_ADMIN_KEY=
+CAP_INSTANCE_URL=http://localhost:3000
 CAP_SITE_KEY=
 CAP_SECRET_KEY=

--- a/example.env
+++ b/example.env
@@ -26,3 +26,10 @@ AWS_ACCESS_KEY_ID=abc
 AWS_SECRET_ACCESS_KEY=abc
 S3_BUCKET=abc
 S3_HOST=abc
+
+# Cap CAPTCHA (optional). Set all three to enable Cap on the signup,
+# login, and password-reset forms. Leave unset to disable (forms work
+# without Cap). See docker-compose.yaml for the cap + valkey services.
+CAP_INSTANCE_URL=
+CAP_SITE_KEY=
+CAP_SECRET_KEY=

--- a/example.env
+++ b/example.env
@@ -33,6 +33,10 @@ S3_HOST=abc
 # CAP_ADMIN_KEY: required by the `cap` docker service at boot (dashboard
 # password). Generate with: openssl rand -hex 32
 CAP_ADMIN_KEY=
-CAP_INSTANCE_URL=http://localhost:3000
+# CAP_INSTANCE_URL: the PUBLIC, browser-reachable HTTPS URL of your Cap
+# instance (the widget renders this into data-cap-api-endpoint, so a
+# user's browser must reach it over HTTPS). http://localhost:3000 works
+# for LOCAL dev only; in production use e.g. https://cap.yourdomain.com.
+CAP_INSTANCE_URL=
 CAP_SITE_KEY=
 CAP_SECRET_KEY=

--- a/lib/shroud/captcha.ex
+++ b/lib/shroud/captcha.ex
@@ -14,7 +14,7 @@ defmodule Shroud.Captcha do
   """
   @spec enabled? :: boolean
   def enabled? do
-    instance_url() != nil and site_key() != nil and secret_key() != nil
+    present?(instance_url()) and present?(site_key()) and present?(secret_key())
   end
 
   @doc """
@@ -45,6 +45,19 @@ defmodule Shroud.Captcha do
   def verify(""), do: {:error, :missing_token}
 
   def verify(token) when is_binary(token) do
+    if enabled?() do
+      verify_token(token)
+    else
+      {:error, :verification_failed}
+    end
+  end
+
+  # Fail-closed catch-all: a non-binary token (e.g. a list or map) returns
+  # verification_failed rather than crashing on String.trim_trailing(nil, "/")
+  # in siteverify_url/0.
+  def verify(_), do: {:error, :verification_failed}
+
+  defp verify_token(token) do
     body = %{"secret" => secret_key(), "response" => token}
 
     case req_post(siteverify_url(), body) do
@@ -67,7 +80,12 @@ defmodule Shroud.Captcha do
       [
         url: url,
         method: :post,
-        json: body
+        json: body,
+        # Bounded so a slow/unreachable Cap instance cannot stall form
+        # submissions. 3s to establish the connection, 5s to read the
+        # response. Both map to Finch via Req (see deps/req/lib/req/steps.ex).
+        connect_options: [timeout: 3_000],
+        receive_timeout: 5_000
       ]
       |> Keyword.merge(Application.get_env(:shroud, :cap_req_options, []))
 
@@ -81,4 +99,13 @@ defmodule Shroud.Captcha do
   defp instance_url, do: Application.get_env(:shroud, :cap_instance_url)
   defp site_key, do: Application.get_env(:shroud, :cap_site_key)
   defp secret_key, do: Application.get_env(:shroud, :cap_secret_key)
+
+  # True only for a binary that is non-empty after trimming. Treats nil,
+  # empty strings, and whitespace-only strings (the values example.env
+  # produces for unset vars) all as "not configured".
+  defp present?(value) when is_binary(value) do
+    String.trim(value) != ""
+  end
+
+  defp present?(_), do: false
 end

--- a/lib/shroud/captcha.ex
+++ b/lib/shroud/captcha.ex
@@ -1,0 +1,84 @@
+defmodule Shroud.Captcha do
+  @moduledoc """
+  Boundary module for the optional Cap CAPTCHA integration.
+
+  Cap is enabled only when all three of CAP_INSTANCE_URL, CAP_SITE_KEY,
+  and CAP_SECRET_KEY are configured. When disabled, every function here
+  is a safe no-op: `enabled?/0` is false, `widget_endpoint/0` is nil, and
+  the `VerifyCaptcha` plug short-circuits.
+  """
+
+  @doc """
+  True iff all three Cap env vars are configured. This is the single gate
+  the rest of the app checks to decide whether Cap is active.
+  """
+  @spec enabled? :: boolean
+  def enabled? do
+    instance_url() != nil and site_key() != nil and secret_key() != nil
+  end
+
+  @doc """
+  The widget's `data-cap-api-endpoint` value: the Cap instance URL plus the
+  site key, with a guaranteed trailing slash. Returns nil when Cap is
+  disabled (so the widget is not rendered at all).
+  """
+  @spec widget_endpoint :: String.t() | nil
+  def widget_endpoint do
+    if enabled?() do
+      "#{String.trim_trailing(instance_url(), "/")}/#{site_key()}/"
+    else
+      nil
+    end
+  end
+
+  @doc """
+  Verify a Cap token against the Standalone `/siteverify` endpoint.
+
+  Returns `:ok` on success, or one of:
+    * `{:error, :missing_token}` — token was nil or empty
+    * `{:error, :verification_failed}` — Cap rejected the token
+    * `{:error, :network_error}` — the HTTP call failed or response was
+      unparseable. Fail-closed: callers should reject the request.
+  """
+  @spec verify(String.t() | nil) :: :ok | {:error, atom}
+  def verify(nil), do: {:error, :missing_token}
+  def verify(""), do: {:error, :missing_token}
+
+  def verify(token) when is_binary(token) do
+    body = %{"secret" => secret_key(), "response" => token}
+
+    case req_post(siteverify_url(), body) do
+      {:ok, %Req.Response{status: 200, body: %{"success" => true}}} ->
+        :ok
+
+      {:ok, %Req.Response{body: %{"success" => _}}} ->
+        {:error, :verification_failed}
+
+      {:ok, %Req.Response{}} ->
+        {:error, :verification_failed}
+
+      {:error, _reason} ->
+        {:error, :network_error}
+    end
+  end
+
+  defp req_post(url, body) do
+    options =
+      [
+        url: url,
+        method: :post,
+        json: body
+      ]
+      |> Keyword.merge(Application.get_env(:shroud, :cap_req_options, []))
+
+    Req.request(options)
+  end
+
+  defp siteverify_url do
+    "#{String.trim_trailing(instance_url(), "/")}/#{site_key()}/siteverify"
+  end
+
+  defp instance_url, do: Application.get_env(:shroud, :cap_instance_url)
+  defp site_key, do: Application.get_env(:shroud, :cap_site_key)
+  defp secret_key, do: Application.get_env(:shroud, :cap_secret_key)
+end

--- a/lib/shroud_web.ex
+++ b/lib/shroud_web.ex
@@ -41,6 +41,7 @@ defmodule ShroudWeb do
 
       import ShroudWeb.ErrorHelpers
       import ShroudWeb.Components.Atoms
+      import ShroudWeb.Components.Cap
 
       use Gettext, backend: ShroudWeb.Gettext
 

--- a/lib/shroud_web/components/cap.ex
+++ b/lib/shroud_web/components/cap.ex
@@ -1,0 +1,36 @@
+defmodule ShroudWeb.Components.Cap do
+  @moduledoc """
+  Renders the Cap CAPTCHA widget.
+
+  Renders nothing when Cap is disabled (any CAP_* env var unset), which
+  keeps the integration optional for self-hosters.
+
+  The widget script is pinned to a specific version (per Cap's "pin the
+  version" guidance) and loaded once. The `<cap-widget>` custom element
+  injects its own hidden `cap-token` input into the surrounding form.
+  """
+
+  use Phoenix.Component
+
+  alias Shroud.Captcha
+
+  attr(:class, :string, default: nil)
+
+  def cap_widget(assigns) do
+    if Captcha.enabled?() do
+      ~H"""
+      <div class={["cap-widget-wrapper", @class]}>
+        <script src={widget_script_url()}>
+        </script>
+        <cap-widget data-cap-api-endpoint={Captcha.widget_endpoint()}></cap-widget>
+      </div>
+      """
+    else
+      ~H""
+    end
+  end
+
+  # Pinned per Cap integration guide ("common failure: version unpinned").
+  defp widget_script_url,
+    do: "https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.56"
+end

--- a/lib/shroud_web/components/cap.ex
+++ b/lib/shroud_web/components/cap.ex
@@ -19,10 +19,17 @@ defmodule ShroudWeb.Components.Cap do
   def cap_widget(assigns) do
     if Captcha.enabled?() do
       ~H"""
-      <div class={["cap-widget-wrapper", @class]}>
+      <div
+        class={["cap-widget-wrapper w-full mb-2", @class]}
+        style={"--cap-widget-width: 100%"}
+      >
         <script src={widget_script_url()}>
         </script>
-        <cap-widget data-cap-api-endpoint={Captcha.widget_endpoint()}></cap-widget>
+        <cap-widget
+          data-cap-api-endpoint={Captcha.widget_endpoint()}
+          class="block w-full"
+        >
+        </cap-widget>
       </div>
       """
     else

--- a/lib/shroud_web/components/cap.ex
+++ b/lib/shroud_web/components/cap.ex
@@ -7,8 +7,7 @@ defmodule ShroudWeb.Components.Cap do
 
   The widget JS is bundled into the main `app.js` esbuild bundle (a
   side-effect import in `assets/js/app.js` self-registers the
-  `<cap-widget>` custom element) rather than loaded from a CDN, per the
-  "never use external CDNs" rule. Its version is pinned in
+  `<cap-widget>` custom element); its version is pinned in
   `assets/package.json`. The `<cap-widget>` element injects its own hidden
   `cap-token` input into the surrounding form.
   """

--- a/lib/shroud_web/components/cap.ex
+++ b/lib/shroud_web/components/cap.ex
@@ -5,9 +5,12 @@ defmodule ShroudWeb.Components.Cap do
   Renders nothing when Cap is disabled (any CAP_* env var unset), which
   keeps the integration optional for self-hosters.
 
-  The widget script is pinned to a specific version (per Cap's "pin the
-  version" guidance) and loaded once. The `<cap-widget>` custom element
-  injects its own hidden `cap-token` input into the surrounding form.
+  The widget JS is bundled into the main `app.js` esbuild bundle (a
+  side-effect import in `assets/js/app.js` self-registers the
+  `<cap-widget>` custom element) rather than loaded from a CDN, per the
+  "never use external CDNs" rule. Its version is pinned in
+  `assets/package.json`. The `<cap-widget>` element injects its own hidden
+  `cap-token` input into the surrounding form.
   """
 
   use Phoenix.Component
@@ -21,10 +24,8 @@ defmodule ShroudWeb.Components.Cap do
       ~H"""
       <div
         class={["cap-widget-wrapper w-full mb-2", @class]}
-        style={"--cap-widget-width: 100%"}
+        style="--cap-widget-width: 100%"
       >
-        <script src={widget_script_url()}>
-        </script>
         <cap-widget
           data-cap-api-endpoint={Captcha.widget_endpoint()}
           class="block w-full"
@@ -36,8 +37,4 @@ defmodule ShroudWeb.Components.Cap do
       ~H""
     end
   end
-
-  # Pinned per Cap integration guide ("common failure: version unpinned").
-  defp widget_script_url,
-    do: "https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.56"
 end

--- a/lib/shroud_web/controllers/user_registration_controller.ex
+++ b/lib/shroud_web/controllers/user_registration_controller.ex
@@ -5,6 +5,8 @@ defmodule ShroudWeb.UserRegistrationController do
   alias Shroud.Accounts.User
   alias ShroudWeb.UserAuth
 
+  plug ShroudWeb.Plugs.VerifyCaptcha when action in [:create]
+
   def new(conn, params) do
     lifetime = params["lifetime"] == "true"
     changeset = Accounts.change_user_registration(%User{})

--- a/lib/shroud_web/controllers/user_registration_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_registration_html/new.html.heex
@@ -38,6 +38,8 @@
           </div>
         </div>
 
+        <.cap_widget />
+
         <div>
           <%= submit "Sign up", disabled: Application.fetch_env!(:shroud, :disable_signups), class: "w-full btn btn-primary disabled:cursor-not-allowed disabled:opacity-50" %>
           <p class="text-sm mt-3 text-center">

--- a/lib/shroud_web/controllers/user_reset_password_controller.ex
+++ b/lib/shroud_web/controllers/user_reset_password_controller.ex
@@ -4,6 +4,7 @@ defmodule ShroudWeb.UserResetPasswordController do
   alias Shroud.Accounts
 
   plug :get_user_by_reset_password_token when action in [:edit, :update]
+  plug ShroudWeb.Plugs.VerifyCaptcha when action in [:create]
 
   def new(conn, _params) do
     render(conn, "new.html")

--- a/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_reset_password_html/new.html.heex
@@ -19,6 +19,8 @@
           </div>
         </div>
 
+        <.cap_widget />
+
         <div>
           <%= submit "Send instructions to reset password", class: "btn btn-primary w-full" %>
         </div>

--- a/lib/shroud_web/controllers/user_session_controller.ex
+++ b/lib/shroud_web/controllers/user_session_controller.ex
@@ -4,6 +4,8 @@ defmodule ShroudWeb.UserSessionController do
   alias Shroud.Accounts
   alias ShroudWeb.UserAuth
 
+  plug ShroudWeb.Plugs.VerifyCaptcha when action in [:create]
+
   def new(conn, _params) do
     render(conn, "new.html", error_message: nil, page_title: "Log in")
   end

--- a/lib/shroud_web/controllers/user_session_html/new.html.heex
+++ b/lib/shroud_web/controllers/user_session_html/new.html.heex
@@ -47,6 +47,8 @@
           </div>
         </div>
 
+        <.cap_widget />
+
         <div>
           <%= submit "Sign in", class: "btn btn-primary w-full" %>
         </div>

--- a/lib/shroud_web/plugs/verify_captcha.ex
+++ b/lib/shroud_web/plugs/verify_captcha.ex
@@ -1,0 +1,50 @@
+defmodule ShroudWeb.Plugs.VerifyCaptcha do
+  @moduledoc """
+  Verifies the Cap CAPTCHA token on protected form submissions.
+
+  This plug is a **no-op when Cap is disabled** (any of the three CAP_*
+  env vars unset), which is what makes Cap optional for self-hosters.
+
+  When enabled, it reads `cap-token` from the request params and verifies
+  it via `Shroud.Captcha.verify/1` before the controller action runs.
+  On failure it flashes an error and redirects back to the form.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias Shroud.Captcha
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    if Captcha.enabled?() do
+      verify_token(conn, conn.params["cap-token"])
+    else
+      conn
+    end
+  end
+
+  defp verify_token(conn, token) do
+    case Captcha.verify(token) do
+      :ok ->
+        conn
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "CAPTCHA verification failed. Please try again.")
+        |> redirect(to: form_route(conn))
+        |> halt()
+    end
+  end
+
+  # Redirect back to the form that was being submitted. We key off the
+  # request path so each protected route returns to its own form.
+  defp form_route(%Plug.Conn{request_path: "/users/log_in"}), do: "/users/log_in"
+  defp form_route(%Plug.Conn{request_path: "/users/reset_password"}), do: "/users/reset_password"
+  defp form_route(_conn), do: "/users/register"
+end

--- a/lib/shroud_web/plugs/verify_captcha.ex
+++ b/lib/shroud_web/plugs/verify_captcha.ex
@@ -29,17 +29,24 @@ defmodule ShroudWeb.Plugs.VerifyCaptcha do
     end
   end
 
-  defp verify_token(conn, token) do
+  defp verify_token(conn, token) when is_binary(token) do
     case Captcha.verify(token) do
-      :ok ->
-        conn
-
-      {:error, _reason} ->
-        conn
-        |> put_flash(:error, "CAPTCHA verification failed. Please try again.")
-        |> redirect(to: form_route(conn))
-        |> halt()
+      :ok -> conn
+      {:error, _reason} -> reject(conn)
     end
+  end
+
+  # The widget injects `cap-token` as a hidden string input, so a binary is
+  # the only valid shape. Anything else (e.g. a list from `?cap-token[]=x` or
+  # a map) is a malformed request — reject it here rather than trusting the
+  # boundary module's clauses to handle every non-binary value.
+  defp verify_token(conn, _non_binary_token), do: reject(conn)
+
+  defp reject(conn) do
+    conn
+    |> put_flash(:error, "CAPTCHA verification failed. Please try again.")
+    |> redirect(to: form_route(conn))
+    |> halt()
   end
 
   # Redirect back to the form that was being submitted. We key off the

--- a/mix.exs
+++ b/mix.exs
@@ -89,6 +89,7 @@ defmodule Shroud.MixProject do
       {:finch, "~> 0.22"},
       {:timex, "~> 3.7"},
       {:httpoison, "~> 2.3"},
+      {:req, "~> 0.6"},
       {:quantum, "~> 3.4"},
       {:nimble_totp, "~> 1.0"},
       {:eqrcode, "~> 0.2.0"},

--- a/test/shroud/captcha_test.exs
+++ b/test/shroud/captcha_test.exs
@@ -1,0 +1,112 @@
+defmodule Shroud.CaptchaTest do
+  use ExUnit.Case, async: true
+
+  import Req.Test
+
+  alias Shroud.Captcha
+
+  # Helper: set all three env vars so enabled?/0 is true.
+  defp enable_cap do
+    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+    Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+    Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+  end
+
+  defp disable_cap do
+    Application.put_env(:shroud, :cap_instance_url, nil)
+    Application.put_env(:shroud, :cap_site_key, nil)
+    Application.put_env(:shroud, :cap_secret_key, nil)
+  end
+
+  # config/test.exs sets cap_req_options: [plug: {Req.Test, Shroud.Captcha}].
+  # Req.Test routes the POST through our stub. The plug receives a Plug.Conn
+  # for the siteverify request; we read nothing from it and just return JSON.
+  defp siteverify_response(body) do
+    fn conn ->
+      Req.Test.json(conn, body)
+    end
+  end
+
+  describe "enabled?/0" do
+    test "true when all three env vars are set" do
+      enable_cap()
+      assert Captcha.enabled?()
+    after
+      disable_cap()
+    end
+
+    test "false when any env var is nil" do
+      disable_cap()
+      refute Captcha.enabled?()
+
+      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+      refute Captcha.enabled?()
+    after
+      disable_cap()
+    end
+  end
+
+  describe "widget_endpoint/0" do
+    test "returns instance + site key with trailing slash when enabled" do
+      enable_cap()
+      assert Captcha.widget_endpoint() == "https://cap.example.com/a1b2c3d4e5/"
+    after
+      disable_cap()
+    end
+
+    test "returns nil when disabled" do
+      disable_cap()
+      assert Captcha.widget_endpoint() == nil
+    end
+  end
+
+  describe "verify/1" do
+    test "returns :ok when Cap responds success: true" do
+      enable_cap()
+      stub(Shroud.Captcha, siteverify_response(%{"success" => true}))
+
+      assert Captcha.verify("valid-token") == :ok
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :verification_failed} when success: false" do
+      enable_cap()
+
+      stub(
+        Shroud.Captcha,
+        siteverify_response(%{"success" => false, "error" => "Token not found"})
+      )
+
+      assert Captcha.verify("bad-token") == {:error, :verification_failed}
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :missing_token} when token is nil" do
+      enable_cap()
+      assert Captcha.verify(nil) == {:error, :missing_token}
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :missing_token} when token is empty" do
+      enable_cap()
+      assert Captcha.verify("") == {:error, :missing_token}
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :network_error} on transport error (fail-closed)" do
+      enable_cap()
+
+      stub(Shroud.Captcha, fn conn ->
+        Req.Test.transport_error(conn, :econnrefused)
+      end)
+
+      assert Captcha.verify("some-token") == {:error, :network_error}
+    after
+      disable_cap()
+    end
+  end
+end

--- a/test/shroud/captcha_test.exs
+++ b/test/shroud/captcha_test.exs
@@ -46,6 +46,30 @@ defmodule Shroud.CaptchaTest do
     after
       disable_cap()
     end
+
+    test "false when env vars are empty strings (as example.env sets)" do
+      Application.put_env(:shroud, :cap_instance_url, "")
+      Application.put_env(:shroud, :cap_site_key, "")
+      Application.put_env(:shroud, :cap_secret_key, "")
+      refute Captcha.enabled?()
+
+      # Two set, one empty -> still disabled.
+      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+      Application.put_env(:shroud, :cap_secret_key, "")
+      refute Captcha.enabled?()
+    after
+      disable_cap()
+    end
+
+    test "false when env vars are whitespace-only strings" do
+      Application.put_env(:shroud, :cap_instance_url, "   ")
+      Application.put_env(:shroud, :cap_site_key, " \t ")
+      Application.put_env(:shroud, :cap_secret_key, "\n")
+      refute Captcha.enabled?()
+    after
+      disable_cap()
+    end
   end
 
   describe "widget_endpoint/0" do
@@ -107,6 +131,21 @@ defmodule Shroud.CaptchaTest do
       end)
 
       assert Captcha.verify("some-token") == {:error, :network_error}
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :verification_failed} (not a crash) when Cap is disabled" do
+      disable_cap()
+      assert Captcha.verify("some-token") == {:error, :verification_failed}
+    after
+      disable_cap()
+    end
+
+    test "returns {:error, :verification_failed} when given a non-binary token with Cap enabled" do
+      enable_cap()
+      assert Captcha.verify(["not", "a", "binary"]) == {:error, :verification_failed}
+      assert Captcha.verify(%{"response" => "map"}) == {:error, :verification_failed}
     after
       disable_cap()
     end

--- a/test/shroud/captcha_test.exs
+++ b/test/shroud/captcha_test.exs
@@ -1,5 +1,7 @@
 defmodule Shroud.CaptchaTest do
-  use ExUnit.Case, async: true
+  # Mutates global Application env (cap_*) that other tests read via
+  # Captcha.enabled?/0, so it must run serially to stay isolation-safe.
+  use ExUnit.Case, async: false
 
   import Req.Test
 

--- a/test/shroud_web/components/cap_test.exs
+++ b/test/shroud_web/components/cap_test.exs
@@ -1,5 +1,7 @@
 defmodule ShroudWeb.Components.CapTest do
-  use ExUnit.Case, async: true
+  # Mutates global Application env (cap_*) that other tests read via
+  # Captcha.enabled?/0, so it must run serially to stay isolation-safe.
+  use ExUnit.Case, async: false
 
   import Phoenix.LiveViewTest
   alias ShroudWeb.Components.Cap
@@ -8,17 +10,9 @@ defmodule ShroudWeb.Components.CapTest do
   @endpoint_url "https://cap.example.com/abc-site-key/"
 
   setup do
-    prev = Application.get_all_env(:shroud)
-
     on_exit(fn ->
-      # restore by deleting keys we set, then re-applying originals
       [:cap_instance_url, :cap_site_key, :cap_secret_key]
       |> Enum.each(&Application.delete_env(:shroud, &1))
-
-      for {k, v} <- prev, is_map(v) do
-        for {kk, vv} <- v,
-            do: Application.put_env(:shroud, k, Map.put(prev[k] || %{}, kk, vv), persistent: true)
-      end
     end)
 
     :ok
@@ -30,9 +24,9 @@ defmodule ShroudWeb.Components.CapTest do
       |> Enum.each(&Application.delete_env(:shroud, &1))
 
   defp enable_cap do
-    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com", persistent: true)
-    Application.put_env(:shroud, :cap_site_key, "abc-site-key", persistent: true)
-    Application.put_env(:shroud, :cap_secret_key, "secret", persistent: true)
+    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+    Application.put_env(:shroud, :cap_site_key, "abc-site-key")
+    Application.put_env(:shroud, :cap_secret_key, "secret")
   end
 
   test "renders nothing when Cap is disabled" do

--- a/test/shroud_web/components/cap_test.exs
+++ b/test/shroud_web/components/cap_test.exs
@@ -6,7 +6,6 @@ defmodule ShroudWeb.Components.CapTest do
   import Phoenix.LiveViewTest
   alias ShroudWeb.Components.Cap
 
-  @pinned "https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.56"
   @endpoint_url "https://cap.example.com/abc-site-key/"
 
   setup do
@@ -36,14 +35,18 @@ defmodule ShroudWeb.Components.CapTest do
     assert html == ""
   end
 
-  test "renders the pinned widget script and the endpoint when enabled" do
+  test "renders the widget element and the endpoint when enabled" do
     enable_cap()
     html = render_component(&Cap.cap_widget/1, %{class: "mt-4"})
 
-    assert html =~ ~s(src="#{@pinned}")
     assert html =~ ~s(data-cap-api-endpoint="#{@endpoint_url}")
     assert html =~ ~s(<cap-widget)
     assert html =~ "cap-widget-wrapper"
     assert html =~ "mt-4"
+
+    # The widget JS is bundled via app.js, not loaded from a CDN, so the
+    # rendered markup must never reference the CDN or emit a <script> tag.
+    refute html =~ "cdn.jsdelivr.net"
+    refute html =~ "<script"
   end
 end

--- a/test/shroud_web/components/cap_test.exs
+++ b/test/shroud_web/components/cap_test.exs
@@ -1,0 +1,55 @@
+defmodule ShroudWeb.Components.CapTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+  alias ShroudWeb.Components.Cap
+
+  @pinned "https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.56"
+  @endpoint_url "https://cap.example.com/abc-site-key/"
+
+  setup do
+    prev = Application.get_all_env(:shroud)
+
+    on_exit(fn ->
+      # restore by deleting keys we set, then re-applying originals
+      [:cap_instance_url, :cap_site_key, :cap_secret_key]
+      |> Enum.each(&Application.delete_env(:shroud, &1))
+
+      for {k, v} <- prev, is_map(v) do
+        for {kk, vv} <- v,
+            do: Application.put_env(:shroud, k, Map.put(prev[k] || %{}, kk, vv), persistent: true)
+      end
+    end)
+
+    :ok
+  end
+
+  defp disable_cap,
+    do:
+      [:cap_instance_url, :cap_site_key, :cap_secret_key]
+      |> Enum.each(&Application.delete_env(:shroud, &1))
+
+  defp enable_cap do
+    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com", persistent: true)
+    Application.put_env(:shroud, :cap_site_key, "abc-site-key", persistent: true)
+    Application.put_env(:shroud, :cap_secret_key, "secret", persistent: true)
+  end
+
+  test "renders nothing when Cap is disabled" do
+    disable_cap()
+    assert Shroud.Captcha.enabled?() == false
+    html = render_component(&Cap.cap_widget/1, %{class: "mt-4"})
+    assert html == ""
+  end
+
+  test "renders the pinned widget script and the endpoint when enabled" do
+    enable_cap()
+    html = render_component(&Cap.cap_widget/1, %{class: "mt-4"})
+
+    assert html =~ ~s(src="#{@pinned}")
+    assert html =~ ~s(data-cap-api-endpoint="#{@endpoint_url}")
+    assert html =~ ~s(<cap-widget)
+    assert html =~ "cap-widget-wrapper"
+    assert html =~ "mt-4"
+  end
+end

--- a/test/shroud_web/controllers/user_registration_controller_test.exs
+++ b/test/shroud_web/controllers/user_registration_controller_test.exs
@@ -70,18 +70,6 @@ defmodule ShroudWeb.UserRegistrationControllerTest do
   end
 
   describe "POST /users/register with Cap enabled" do
-    defp enable_cap do
-      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
-      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
-      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
-    end
-
-    defp disable_cap do
-      Application.put_env(:shroud, :cap_instance_url, nil)
-      Application.put_env(:shroud, :cap_site_key, nil)
-      Application.put_env(:shroud, :cap_secret_key, nil)
-    end
-
     test "rejects a forged POST with no cap-token", %{conn: conn} do
       enable_cap()
 

--- a/test/shroud_web/controllers/user_registration_controller_test.exs
+++ b/test/shroud_web/controllers/user_registration_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule ShroudWeb.UserRegistrationControllerTest do
-  use ShroudWeb.ConnCase, async: true
+  # Mutates global Application env (cap_*) via enable_cap/disable_cap in the
+  # "Cap enabled" describe block below; must run serially to stay isolation-safe.
+  use ShroudWeb.ConnCase, async: false
 
   import Shroud.AccountsFixtures
 
@@ -64,6 +66,55 @@ defmodule ShroudWeb.UserRegistrationControllerTest do
       # Now do a logged in request and assert on the menu
       conn = get(conn, "/users/confirm")
       assert conn.assigns.current_user.status == :lifetime
+    end
+  end
+
+  describe "POST /users/register with Cap enabled" do
+    defp enable_cap do
+      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+    end
+
+    defp disable_cap do
+      Application.put_env(:shroud, :cap_instance_url, nil)
+      Application.put_env(:shroud, :cap_site_key, nil)
+      Application.put_env(:shroud, :cap_secret_key, nil)
+    end
+
+    test "rejects a forged POST with no cap-token", %{conn: conn} do
+      enable_cap()
+
+      conn =
+        post(conn, ~p"/users/register", %{
+          "user" => valid_user_attributes(email: unique_user_email())
+        })
+
+      assert redirected_to(conn) == "/users/register"
+      assert Flash.get(conn.assigns.flash, :error) =~ "verification"
+    after
+      disable_cap()
+    end
+
+    test "creates account when cap-token verifies", %{conn: conn} do
+      enable_cap()
+
+      Req.Test.stub(Shroud.Captcha, fn conn ->
+        Req.Test.json(conn, %{"success" => true})
+      end)
+
+      email = unique_user_email()
+
+      conn =
+        post(conn, ~p"/users/register", %{
+          "user" => valid_user_attributes(email: email),
+          "cap-token" => "valid-token"
+        })
+
+      assert get_session(conn, :user_token)
+      assert redirected_to(conn) == "/users/confirm"
+    after
+      disable_cap()
     end
   end
 end

--- a/test/shroud_web/controllers/user_registration_controller_test.exs
+++ b/test/shroud_web/controllers/user_registration_controller_test.exs
@@ -4,6 +4,7 @@ defmodule ShroudWeb.UserRegistrationControllerTest do
   use ShroudWeb.ConnCase, async: false
 
   import Shroud.AccountsFixtures
+  import ShroudWeb.CaptchaHelpers
 
   describe "GET /users/register" do
     test "renders registration page", %{conn: conn} do

--- a/test/shroud_web/controllers/user_reset_password_controller_test.exs
+++ b/test/shroud_web/controllers/user_reset_password_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule ShroudWeb.UserResetPasswordControllerTest do
-  use ShroudWeb.ConnCase, async: true
+  # Mutates global Application env (cap_*) via enable_cap/disable_cap in the
+  # "Cap enabled" describe block below; must run serially to stay isolation-safe.
+  use ShroudWeb.ConnCase, async: false
 
   alias Shroud.Accounts
   alias Shroud.Repo
@@ -120,6 +122,53 @@ defmodule ShroudWeb.UserResetPasswordControllerTest do
 
       assert Flash.get(conn.assigns.flash, :error) =~
                "Reset password link is invalid or it has expired"
+    end
+  end
+
+  describe "POST /users/reset_password with Cap enabled" do
+    defp enable_cap do
+      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+    end
+
+    defp disable_cap do
+      Application.put_env(:shroud, :cap_instance_url, nil)
+      Application.put_env(:shroud, :cap_site_key, nil)
+      Application.put_env(:shroud, :cap_secret_key, nil)
+    end
+
+    test "rejects a forged POST with no cap-token", %{conn: conn} do
+      enable_cap()
+
+      conn =
+        post(conn, ~p"/users/reset_password", %{
+          "user" => %{"email" => "someone@example.com"}
+        })
+
+      assert redirected_to(conn) == "/users/reset_password"
+      assert Flash.get(conn.assigns.flash, :error) =~ "verification"
+    after
+      disable_cap()
+    end
+
+    test "sends reset instructions when cap-token verifies", %{conn: conn} do
+      enable_cap()
+
+      Req.Test.stub(Shroud.Captcha, fn conn ->
+        Req.Test.json(conn, %{"success" => true})
+      end)
+
+      conn =
+        post(conn, ~p"/users/reset_password", %{
+          "user" => %{"email" => "someone@example.com"},
+          "cap-token" => "valid-token"
+        })
+
+      assert redirected_to(conn) == "/users/log_in"
+      assert Flash.get(conn.assigns.flash, :info) =~ "If your email is in our system"
+    after
+      disable_cap()
     end
   end
 end

--- a/test/shroud_web/controllers/user_reset_password_controller_test.exs
+++ b/test/shroud_web/controllers/user_reset_password_controller_test.exs
@@ -126,18 +126,6 @@ defmodule ShroudWeb.UserResetPasswordControllerTest do
   end
 
   describe "POST /users/reset_password with Cap enabled" do
-    defp enable_cap do
-      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
-      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
-      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
-    end
-
-    defp disable_cap do
-      Application.put_env(:shroud, :cap_instance_url, nil)
-      Application.put_env(:shroud, :cap_site_key, nil)
-      Application.put_env(:shroud, :cap_secret_key, nil)
-    end
-
     test "rejects a forged POST with no cap-token", %{conn: conn} do
       enable_cap()
 

--- a/test/shroud_web/controllers/user_reset_password_controller_test.exs
+++ b/test/shroud_web/controllers/user_reset_password_controller_test.exs
@@ -6,6 +6,7 @@ defmodule ShroudWeb.UserResetPasswordControllerTest do
   alias Shroud.Accounts
   alias Shroud.Repo
   import Shroud.AccountsFixtures
+  import ShroudWeb.CaptchaHelpers
 
   setup do
     %{user: user_fixture()}

--- a/test/shroud_web/controllers/user_session_controller_test.exs
+++ b/test/shroud_web/controllers/user_session_controller_test.exs
@@ -6,6 +6,7 @@ defmodule ShroudWeb.UserSessionControllerTest do
   alias Shroud.Accounts.User
   alias Shroud.Repo
   import Shroud.AccountsFixtures
+  import ShroudWeb.CaptchaHelpers
 
   setup do
     %{user: user_fixture()}

--- a/test/shroud_web/controllers/user_session_controller_test.exs
+++ b/test/shroud_web/controllers/user_session_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule ShroudWeb.UserSessionControllerTest do
-  use ShroudWeb.ConnCase, async: true
+  # Mutates global Application env (cap_*) via enable_cap/disable_cap in the
+  # "Cap enabled" describe block below; must run serially to stay isolation-safe.
+  use ShroudWeb.ConnCase, async: false
 
   alias Shroud.Accounts.User
   alias Shroud.Repo
@@ -97,6 +99,52 @@ defmodule ShroudWeb.UserSessionControllerTest do
       assert redirected_to(conn) == "/users/log_in"
       refute get_session(conn, :user_token)
       assert Flash.get(conn.assigns.flash, :info) =~ "Logged out successfully"
+    end
+  end
+
+  describe "POST /users/log_in with Cap enabled" do
+    defp enable_cap do
+      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+    end
+
+    defp disable_cap do
+      Application.put_env(:shroud, :cap_instance_url, nil)
+      Application.put_env(:shroud, :cap_site_key, nil)
+      Application.put_env(:shroud, :cap_secret_key, nil)
+    end
+
+    test "rejects a forged POST with no cap-token", %{conn: conn, user: user} do
+      enable_cap()
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/users/log_in"
+      assert Flash.get(conn.assigns.flash, :error) =~ "verification"
+    after
+      disable_cap()
+    end
+
+    test "logs in when cap-token verifies", %{conn: conn, user: user} do
+      enable_cap()
+
+      Req.Test.stub(Shroud.Captcha, fn conn ->
+        Req.Test.json(conn, %{"success" => true})
+      end)
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()},
+          "cap-token" => "valid-token"
+        })
+
+      assert get_session(conn, :user_token)
+    after
+      disable_cap()
     end
   end
 end

--- a/test/shroud_web/controllers/user_session_controller_test.exs
+++ b/test/shroud_web/controllers/user_session_controller_test.exs
@@ -103,18 +103,6 @@ defmodule ShroudWeb.UserSessionControllerTest do
   end
 
   describe "POST /users/log_in with Cap enabled" do
-    defp enable_cap do
-      Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
-      Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
-      Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
-    end
-
-    defp disable_cap do
-      Application.put_env(:shroud, :cap_instance_url, nil)
-      Application.put_env(:shroud, :cap_site_key, nil)
-      Application.put_env(:shroud, :cap_secret_key, nil)
-    end
-
     test "rejects a forged POST with no cap-token", %{conn: conn, user: user} do
       enable_cap()
 

--- a/test/shroud_web/plugs/verify_captcha_test.exs
+++ b/test/shroud_web/plugs/verify_captcha_test.exs
@@ -1,0 +1,97 @@
+defmodule ShroudWeb.Plugs.VerifyCaptchaTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Phoenix.ConnTest
+  import Req.Test
+
+  alias Phoenix.Flash
+  alias ShroudWeb.Plugs.VerifyCaptcha
+
+  defp enable_cap do
+    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+    Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+    Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+  end
+
+  defp disable_cap do
+    Application.put_env(:shroud, :cap_instance_url, nil)
+    Application.put_env(:shroud, :cap_site_key, nil)
+    Application.put_env(:shroud, :cap_secret_key, nil)
+  end
+
+  # Build a Plug.Conn shaped like a Phoenix form POST: parsed params with a
+  # "cap-token" key. We don't go through the router; we invoke the plug
+  # directly so the test is focused on the plug's behavior.
+  defp conn_with_token(token) do
+    build_conn(:post, "/users/register", %{"cap-token" => token})
+  end
+
+  # `put_flash/3` (used inside the plug) requires `conn.assigns.flash` to
+  # already exist. When invoking the plug directly outside a browser
+  # pipeline we pre-populate it ourselves so we can assert on the result.
+  defp for_plug(conn), do: assign(conn, :flash, %{})
+
+  describe "when Cap is disabled" do
+    test "passes the conn through unchanged (no-op)" do
+      disable_cap()
+      conn = conn_with_token("ignored-token")
+      returned = VerifyCaptcha.call(conn, [])
+
+      assert returned == conn
+    after
+      disable_cap()
+    end
+  end
+
+  describe "when Cap is enabled" do
+    test "passes through when verify returns :ok" do
+      enable_cap()
+      stub(Shroud.Captcha, fn conn -> Req.Test.json(conn, %{"success" => true}) end)
+
+      conn = conn_with_token("valid-token")
+      returned = VerifyCaptcha.call(conn, [])
+
+      refute returned.halted
+    after
+      disable_cap()
+    end
+
+    test "rejects (flash + redirect + halt) when token is missing" do
+      enable_cap()
+      conn = build_conn(:post, "/users/register", %{}) |> for_plug()
+
+      returned = VerifyCaptcha.call(conn, [])
+
+      assert returned.halted
+      assert Flash.get(returned.assigns.flash, :error) =~ "verification"
+      assert redirected_to(returned) == "/users/register"
+    after
+      disable_cap()
+    end
+
+    test "rejects when verify returns {:error, :verification_failed}" do
+      enable_cap()
+      stub(Shroud.Captcha, fn conn -> Req.Test.json(conn, %{"success" => false}) end)
+
+      returned = VerifyCaptcha.call(conn_with_token("bad-token") |> for_plug(), [])
+
+      assert returned.halted
+      assert Flash.get(returned.assigns.flash, :error) =~ "verification"
+    after
+      disable_cap()
+    end
+
+    test "rejects (fail-closed) when verify returns {:error, :network_error}" do
+      enable_cap()
+      stub(Shroud.Captcha, fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+
+      returned = VerifyCaptcha.call(conn_with_token("some-token") |> for_plug(), [])
+
+      assert returned.halted
+      assert Flash.get(returned.assigns.flash, :error) =~ "verification"
+    after
+      disable_cap()
+    end
+  end
+end

--- a/test/shroud_web/plugs/verify_captcha_test.exs
+++ b/test/shroud_web/plugs/verify_captcha_test.exs
@@ -1,5 +1,7 @@
 defmodule ShroudWeb.Plugs.VerifyCaptchaTest do
-  use ExUnit.Case, async: true
+  # Mutates global Application env (cap_*) that other tests read via
+  # Captcha.enabled?/0, so it must run serially to stay isolation-safe.
+  use ExUnit.Case, async: false
 
   import Plug.Conn
   import Phoenix.ConnTest

--- a/test/shroud_web/plugs/verify_captcha_test.exs
+++ b/test/shroud_web/plugs/verify_captcha_test.exs
@@ -95,5 +95,20 @@ defmodule ShroudWeb.Plugs.VerifyCaptchaTest do
     after
       disable_cap()
     end
+
+    test "rejects (fail-closed) when cap-token is a list instead of crashing" do
+      enable_cap()
+      # A malformed request like `?cap-token[]=x` parses `cap-token` into a
+      # list. The plug must reject it rather than crash with FunctionClauseError.
+      conn = build_conn(:post, "/users/register", %{"cap-token" => ["x"]}) |> for_plug()
+
+      returned = VerifyCaptcha.call(conn, [])
+
+      assert returned.halted
+      assert Flash.get(returned.assigns.flash, :error) =~ "verification"
+      assert redirected_to(returned) == "/users/register"
+    after
+      disable_cap()
+    end
   end
 end

--- a/test/support/captcha_helpers.ex
+++ b/test/support/captcha_helpers.ex
@@ -1,0 +1,19 @@
+defmodule ShroudWeb.CaptchaHelpers do
+  @moduledoc """
+  Test helpers for the optional Cap CAPTCHA integration. These mutate
+  global `Application` env, so tests using them MUST run with `async: false`
+  (the Cap controller tests already do).
+  """
+
+  def enable_cap do
+    Application.put_env(:shroud, :cap_instance_url, "https://cap.example.com")
+    Application.put_env(:shroud, :cap_site_key, "a1b2c3d4e5")
+    Application.put_env(:shroud, :cap_secret_key, "sk-testsecret")
+  end
+
+  def disable_cap do
+    Application.put_env(:shroud, :cap_instance_url, nil)
+    Application.put_env(:shroud, :cap_site_key, nil)
+    Application.put_env(:shroud, :cap_secret_key, nil)
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -25,6 +25,7 @@ defmodule ShroudWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import ShroudWeb.ConnCase
+      import ShroudWeb.CaptchaHelpers
       alias Phoenix.Flash
 
       use ShroudWeb, :verified_routes

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -25,7 +25,6 @@ defmodule ShroudWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import ShroudWeb.ConnCase
-      import ShroudWeb.CaptchaHelpers
       alias Phoenix.Flash
 
       use ShroudWeb, :verified_routes


### PR DESCRIPTION
This adds support for [Cap](https://trycap.dev/), a self-hosted and privacy-preserving CAPTCHA.

The goal is to prevent bot signups and brute-force attempts.