### PR TITLE
fix: reject RFC-5322-invalid emails

### DIFF
--- a/lib/shroud/accounts.ex
+++ b/lib/shroud/accounts.ex
@@ -7,7 +7,7 @@ defmodule Shroud.Accounts do
   alias Shroud.Repo
 
   alias Shroud.Notifier
-  alias Shroud.Accounts.{LoopsJob, User, UserToken, UserNotifier}
+  alias Shroud.Accounts.{LoopsJob, User, UserNotifier, UserNotifierJob, UserToken}
   alias Shroud.Aliases.EmailAlias
 
   require Logger
@@ -273,10 +273,14 @@ defmodule Shroud.Accounts do
   @doc """
   Delivers the confirmation email instructions to the given user.
 
+  The confirmation token is persisted synchronously, but the email itself is
+  sent asynchronously via an `UserNotifierJob` so transient SMTP failures are
+  retried by Oban instead of blocking or failing signup.
+
   ## Examples
 
       iex> deliver_user_confirmation_instructions(user, &url(~p"/users/confirm/\#{&1}"))
-      {:ok, %{to: ..., body: ...}}
+      {:ok, %Oban.Job{}}
 
       iex> deliver_user_confirmation_instructions(confirmed_user, &url(~p"/users/confirm/\#{&1}"))
       {:error, :already_confirmed}
@@ -289,7 +293,16 @@ defmodule Shroud.Accounts do
     else
       {encoded_token, user_token} = UserToken.build_email_token(user, "confirm")
       Repo.insert!(user_token)
-      UserNotifier.deliver_confirmation_instructions(user, confirmation_url_fun.(encoded_token))
+
+      job =
+        %{
+          email_function: "deliver_confirmation_instructions",
+          email_args: [user.id, confirmation_url_fun.(encoded_token)]
+        }
+        |> UserNotifierJob.new()
+        |> Oban.insert!()
+
+      {:ok, job}
     end
   end
 

--- a/lib/shroud/accounts.ex
+++ b/lib/shroud/accounts.ex
@@ -273,10 +273,6 @@ defmodule Shroud.Accounts do
   @doc """
   Delivers the confirmation email instructions to the given user.
 
-  The confirmation token is persisted synchronously, but the email itself is
-  sent asynchronously via an `UserNotifierJob` so transient SMTP failures are
-  retried by Oban instead of blocking or failing signup.
-
   ## Examples
 
       iex> deliver_user_confirmation_instructions(user, &url(~p"/users/confirm/\#{&1}"))

--- a/lib/shroud/accounts/user.ex
+++ b/lib/shroud/accounts/user.ex
@@ -61,10 +61,25 @@ defmodule Shroud.Accounts.User do
   defp validate_email(changeset) do
     changeset
     |> validate_required([:email])
-    |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must have the @ sign and no spaces")
+    |> validate_change(:email, &validate_email_format/2)
     |> validate_length(:email, max: 160)
     |> unsafe_validate_unique(:email, Shroud.Repo)
     |> unique_constraint(:email)
+  end
+
+  # Validates the email against gen_smtp's RFC 5322 parser — the *same* parser
+  # that Swoosh.Adapters.SMTP invokes (via :mimemail.encode) when building
+  # outgoing mail. Delegating to it means validation can never drift from what
+  # the mailer will accept: any address the parser rejects would later raise a
+  # MatchError in `mimemail.encode_header_value/2` (which hard-matches on
+  # `{ok, _} = parse_rfc5322_addresses/1`), 500-ing the request after the user
+  # row was already saved. We require a single bare address (no display name,
+  # no comma-separated list), matching what a signup form should accept.
+  defp validate_email_format(:email, email) do
+    case :smtp_util.parse_rfc5322_addresses(email) do
+      {:ok, [{:undefined, _address}]} -> []
+      _ -> [email: "is invalid"]
+    end
   end
 
   defp validate_password(changeset, opts) do

--- a/lib/shroud/accounts/user.ex
+++ b/lib/shroud/accounts/user.ex
@@ -67,14 +67,8 @@ defmodule Shroud.Accounts.User do
     |> unique_constraint(:email)
   end
 
-  # Validates the email against gen_smtp's RFC 5322 parser — the *same* parser
-  # that Swoosh.Adapters.SMTP invokes (via :mimemail.encode) when building
-  # outgoing mail. Delegating to it means validation can never drift from what
-  # the mailer will accept: any address the parser rejects would later raise a
-  # MatchError in `mimemail.encode_header_value/2` (which hard-matches on
-  # `{ok, _} = parse_rfc5322_addresses/1`), 500-ing the request after the user
-  # row was already saved. We require a single bare address (no display name,
-  # no comma-separated list), matching what a signup form should accept.
+  # Validates the email against gen_smtp's RFC 5322 parser — the same parser
+  # we use for outgoing mail.
   defp validate_email_format(:email, email) do
     case :smtp_util.parse_rfc5322_addresses(email) do
       {:ok, [{:undefined, _address}]} -> []

--- a/lib/shroud/accounts/user_notifier.ex
+++ b/lib/shroud/accounts/user_notifier.ex
@@ -1,11 +1,27 @@
 defmodule Shroud.Accounts.UserNotifier do
   import Swoosh.Email
 
+  require Logger
+
   alias Shroud.{Accounts, EmailTemplate, Mailer, Util, Repo}
   alias Shroud.Domain.CustomDomain
   use ShroudWeb, :verified_routes
 
   # Delivers the email using the application mailer.
+  #
+  # Swoosh.Adapters.SMTP builds the MIME message via :mimemail.encode, whose
+  # `encode_header_value/2` does a hard `{ok, _} =
+  # smtp_util:parse_rfc5322_addresses/1` match — it *raises* a MatchError
+  # (rather than returning {:error, _}) on RFC 5322-invalid addresses (e.g.
+  # consecutive dots). We catch any exception here, report it to Sentry, and
+  # return {:error, _} so callers degrade gracefully instead of 500-ing.
+  #
+  # Sentry capture is explicit because the app's Sentry.LoggerHandler is
+  # configured with the default `capture_log_messages: false`, so a plain
+  # Logger.error would NOT be reported — only an unhandled crash would (via
+  # Sentry.PlugCapture). Several notifier call sites deliberately ignore the
+  # return value (to avoid user-enumeration leaks), so without this capture a
+  # swallowed raise would vanish from Sentry entirely.
   defp deliver(recipient, subject, html_body, text_body) do
     email =
       new()
@@ -16,15 +32,37 @@ defmodule Shroud.Accounts.UserNotifier do
       |> html_body(html_body)
       |> text_body(text_body)
 
-    with {:ok, _metadata} <- Mailer.deliver(email) do
-      {:ok, email}
+    case Mailer.deliver(email) do
+      {:ok, _metadata} -> {:ok, email}
+      {:error, reason} -> {:error, reason}
     end
+  rescue
+    exception ->
+      stacktrace = __STACKTRACE__
+
+      Logger.error("""
+      Failed to deliver email to #{inspect(recipient)}: #{Exception.format(:error, exception, stacktrace)}
+      """)
+
+      Sentry.capture_exception(exception,
+        stacktrace: stacktrace,
+        extra: %{recipient: recipient, subject: subject}
+      )
+
+      {:error, {:delivery_failed, exception}}
   end
 
   @doc """
   Deliver instructions to confirm account.
+
+  Takes a `user_id` (rather than a `%User{}`) so it can be enqueued as an
+  `UserNotifierJob` and run asynchronously — the user is fetched fresh inside
+  the job. This keeps confirmation delivery off the request path so transient
+  SMTP failures are retried by Oban instead of blocking or failing signup.
   """
-  def deliver_confirmation_instructions(user, url) do
+  def deliver_confirmation_instructions(user_id, url) do
+    user = Accounts.get_user!(user_id)
+
     html_body =
       EmailTemplate.ConfirmationInstructions.render(
         user_email: user.email,

--- a/lib/shroud/accounts/user_notifier.ex
+++ b/lib/shroud/accounts/user_notifier.ex
@@ -8,20 +8,6 @@ defmodule Shroud.Accounts.UserNotifier do
   use ShroudWeb, :verified_routes
 
   # Delivers the email using the application mailer.
-  #
-  # Swoosh.Adapters.SMTP builds the MIME message via :mimemail.encode, whose
-  # `encode_header_value/2` does a hard `{ok, _} =
-  # smtp_util:parse_rfc5322_addresses/1` match — it *raises* a MatchError
-  # (rather than returning {:error, _}) on RFC 5322-invalid addresses (e.g.
-  # consecutive dots). We catch any exception here, report it to Sentry, and
-  # return {:error, _} so callers degrade gracefully instead of 500-ing.
-  #
-  # Sentry capture is explicit because the app's Sentry.LoggerHandler is
-  # configured with the default `capture_log_messages: false`, so a plain
-  # Logger.error would NOT be reported — only an unhandled crash would (via
-  # Sentry.PlugCapture). Several notifier call sites deliberately ignore the
-  # return value (to avoid user-enumeration leaks), so without this capture a
-  # swallowed raise would vanish from Sentry entirely.
   defp deliver(recipient, subject, html_body, text_body) do
     email =
       new()
@@ -54,11 +40,6 @@ defmodule Shroud.Accounts.UserNotifier do
 
   @doc """
   Deliver instructions to confirm account.
-
-  Takes a `user_id` (rather than a `%User{}`) so it can be enqueued as an
-  `UserNotifierJob` and run asynchronously — the user is fetched fresh inside
-  the job. This keeps confirmation delivery off the request path so transient
-  SMTP failures are retried by Oban instead of blocking or failing signup.
   """
   def deliver_confirmation_instructions(user_id, url) do
     user = Accounts.get_user!(user_id)

--- a/lib/shroud/accounts/user_notifier_job.ex
+++ b/lib/shroud/accounts/user_notifier_job.ex
@@ -1,10 +1,37 @@
 defmodule Shroud.Accounts.UserNotifierJob do
+  @moduledoc """
+  Oban worker that sends transactional emails asynchronously.
+  """
   use Oban.Worker, queue: :outgoing_email, max_attempts: 10
-  alias Shroud.Accounts
+
+  alias Shroud.Accounts.UserNotifier
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"email_function" => email_function, "email_args" => email_args}}) do
-    email_function = String.to_existing_atom(email_function)
-    apply(Accounts.UserNotifier, email_function, email_args)
+    case email_function do
+      "deliver_confirmation_instructions" ->
+        apply(UserNotifier, :deliver_confirmation_instructions, email_args)
+
+      "deliver_domain_verified" ->
+        apply(UserNotifier, :deliver_domain_verified, email_args)
+
+      "deliver_domain_no_longer_verified" ->
+        apply(UserNotifier, :deliver_domain_no_longer_verified, email_args)
+
+      "deliver_incoming_email_marked_as_spam" ->
+        apply(UserNotifier, :deliver_incoming_email_marked_as_spam, email_args)
+
+      "deliver_outgoing_email_marked_as_spam" ->
+        apply(UserNotifier, :deliver_outgoing_email_marked_as_spam, email_args)
+
+      "deliver_reset_password_instructions" ->
+        apply(UserNotifier, :deliver_reset_password_instructions, email_args)
+
+      "deliver_update_email_instructions" ->
+        apply(UserNotifier, :deliver_update_email_instructions, email_args)
+
+      other ->
+        {:error, {:unknown_email_function, other}}
+    end
   end
 end

--- a/test/shroud/accounts/user_notifier_job_test.exs
+++ b/test/shroud/accounts/user_notifier_job_test.exs
@@ -33,5 +33,17 @@ defmodule Shroud.Accounts.UserNotifierJobTest do
 
       assert_email_sent(to: user.email, subject: "#{domain.domain} is no longer verified")
     end
+
+    test "sends confirmation_instructions (dispatched by string name, as enqueued)" do
+      user = user_fixture()
+
+      assert {:ok, _email} =
+               perform_job(UserNotifierJob, %{
+                 "email_function" => "deliver_confirmation_instructions",
+                 "email_args" => [user.id, "https://example.com/confirm/token"]
+               })
+
+      assert_email_sent(to: user.email, subject: "Confirmation instructions")
+    end
   end
 end

--- a/test/shroud/accounts/user_notifier_test.exs
+++ b/test/shroud/accounts/user_notifier_test.exs
@@ -1,0 +1,48 @@
+defmodule Shroud.Accounts.UserNotifierTest do
+  use Shroud.DataCase, async: false
+
+  import Shroud.AccountsFixtures
+
+  alias Shroud.Accounts.UserNotifier
+
+  # A throwaway Swoosh adapter that mimics :mimemail.encode raising a MatchError
+  # (exactly as gen_smtp does on RFC-5322-invalid addresses like "a..b@example.com").
+  # Swoosh.Adapters.SMTP calls :mimemail.encode before any network I/O, so the
+  # raise happens synchronously inside deliver/2 — no real SMTP server needed.
+  defmodule RaisingAdapter do
+    @behaviour Swoosh.Adapter
+
+    @impl true
+    def validate_config(_config), do: :ok
+
+    @impl true
+    def deliver(_email, _config) do
+      raise MatchError,
+        term: {:error, {1, :smtp_rfc5322_parse, [~c"syntax error before: ", ~c"'.'"]}}
+    end
+
+    @impl true
+    def validate_dependency, do: :ok
+  end
+
+  setup do
+    original = Application.get_env(:shroud, Shroud.Mailer, [])
+    Application.put_env(:shroud, Shroud.Mailer, Keyword.put(original, :adapter, RaisingAdapter))
+
+    on_exit(fn -> Application.put_env(:shroud, Shroud.Mailer, original) end)
+
+    :ok
+  end
+
+  describe "deliver/4 when the mailer raises" do
+    test "returns {:error, _} instead of propagating the exception" do
+      user = user_fixture()
+
+      # deliver_confirmation_instructions exercises deliver/4 internally.
+      result =
+        UserNotifier.deliver_confirmation_instructions(user.id, "https://example.com/confirm")
+
+      assert match?({:error, _}, result)
+    end
+  end
+end

--- a/test/shroud/accounts/user_test.exs
+++ b/test/shroud/accounts/user_test.exs
@@ -1,0 +1,105 @@
+defmodule Shroud.Accounts.UserTest do
+  use Shroud.DataCase, async: true
+
+  alias Shroud.Accounts.User
+
+  describe "registration_changeset/2 email validation" do
+    # Email validity is checked with gen_smtp's own RFC 5322 parser
+    # (:smtp_util.parse_rfc5322_addresses/1) — the same parser Swoosh invokes
+    # via :mimemail.encode when sending mail. Addresses the parser rejects
+    # previously crashed the SMTP encode path with a raised MatchError,
+    # 500-ing POST /users/register after the user row was already saved.
+    # Using the parser directly means validation can never drift from what the
+    # mailer will actually accept.
+
+    @invalid_dot_addresses [
+      {"consecutive dots in local part", "a..b@example.com"},
+      {"three consecutive dots in local part", "a...b@example.com"},
+      {"leading dot in local part", ".foo@example.com"},
+      {"trailing dot in local part", "foo.@example.com"},
+      {"consecutive dots in domain", "foo@ex..ample.com"},
+      {"leading dot in domain", "foo@.example.com"},
+      {"trailing dot in domain", "foo@example.com."}
+    ]
+
+    for {label, email} <- @invalid_dot_addresses do
+      @tag label: label
+      test "rejects #{label}: #{email}" do
+        changeset =
+          User.registration_changeset(%User{}, %{
+            email: unquote(email),
+            password: "hello world!"
+          })
+
+        refute changeset.valid?, "expected #{inspect(unquote(email))} to be rejected"
+        assert Keyword.has_key?(changeset.errors, :email)
+        {message, _} = Keyword.get(changeset.errors, :email)
+        assert message =~ "is invalid"
+      end
+    end
+
+    @valid_addresses [
+      "first.last@gmail.com",
+      "a.b@example.com",
+      "foo@localhost",
+      "foo+bar@gmail.com",
+      "foo_bar@example.com",
+      "foo-bar@example.com",
+      "foo@ex-ample.com",
+      "12345@example.com",
+      "foo@a.b.example.com",
+      "üñîçødé@example.com",
+      # Quoted local parts are valid RFC 5322 and accepted by gen_smtp.
+      "\"foo bar\"@example.com",
+      # Domain-literal form (RFC 5322) — accepted by gen_smtp's parser. This
+      # also discriminates parser-based validation from a hand-rolled regex,
+      # which would reject the bracketed domain.
+      "foo@[127.0.0.1]"
+    ]
+
+    # A signup form should accept a single bare address only — not a display
+    # name form, not a comma-separated list. These parse as valid RFC 5322 but
+    # are not a single plain address.
+    @non_bare_forms [
+      {"display name form", "Foo <foo@example.com>"},
+      {"comma-separated list", "a@b.com, c@d.com"}
+    ]
+
+    for {label, email} <- @non_bare_forms do
+      @tag label: label
+      test "rejects non-bare address: #{label}" do
+        changeset =
+          User.registration_changeset(%User{}, %{
+            email: unquote(email),
+            password: "hello world!"
+          })
+
+        refute changeset.valid?, "expected #{inspect(unquote(email))} to be rejected"
+        assert Keyword.has_key?(changeset.errors, :email)
+      end
+    end
+
+    for email <- @valid_addresses do
+      @tag email: email
+      test "accepts valid address: #{email}" do
+        changeset =
+          User.registration_changeset(%User{}, %{
+            email: unquote(email),
+            password: "hello world!"
+          })
+
+        # Only the email-specific validations should pass; ignore any
+        # unsafe_validate_unique errors from a pre-existing row.
+        email_errors =
+          changeset.errors
+          |> Keyword.get_values(:email)
+          |> Enum.reject(fn {_msg, opts} ->
+            opts[:validation] == :unsafe_unique
+          end)
+
+        assert email_errors == [],
+               "expected #{inspect(unquote(email))} to pass validation, got errors: #{inspect(email_errors)}"
+      end
+    end
+  end
+end

--- a/test/shroud/accounts_test.exs
+++ b/test/shroud/accounts_test.exs
@@ -84,7 +84,7 @@ defmodule Shroud.AccountsTest do
       {:error, changeset} = Accounts.register_user(%{email: "not valid", password: "not valid"})
 
       assert %{
-               email: ["must have the @ sign and no spaces"],
+               email: ["is invalid"],
                password: ["should be at least 12 character(s)"]
              } = errors_on(changeset)
     end
@@ -177,7 +177,7 @@ defmodule Shroud.AccountsTest do
       {:error, changeset} =
         Accounts.apply_user_email(user, valid_user_password(), %{email: "not valid"})
 
-      assert %{email: ["must have the @ sign and no spaces"]} = errors_on(changeset)
+      assert %{email: ["is invalid"]} = errors_on(changeset)
     end
 
     test "validates maximum value for email for security", %{user: user} do
@@ -406,29 +406,24 @@ defmodule Shroud.AccountsTest do
       %{user: user_fixture()}
     end
 
-    test "sends token through notification", %{user: user} do
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(user, url)
-        end)
+    test "enqueues the confirmation email job and persists a token", %{user: user} do
+      url_fun = &"https://example.com/confirm/#{&1}"
 
-      {:ok, token} = Base.url_decode64(token, padding: false)
-      assert user_token = Repo.get_by(UserToken, token: :crypto.hash(:sha256, token))
-      assert user_token.user_id == user.id
-      assert user_token.sent_to == user.email
-      assert user_token.context == "confirm"
+      assert {:ok, %Oban.Job{} = job} =
+               Accounts.deliver_user_confirmation_instructions(user, url_fun)
+
+      assert job.args[:email_function] == "deliver_confirmation_instructions"
+      assert hd(job.args[:email_args]) == user.id
+
+      # A confirmation token is persisted regardless of email delivery.
+      assert %UserToken{context: "confirm"} = Repo.get_by(UserToken, user_id: user.id)
     end
   end
 
   describe "confirm_user/1" do
     setup do
       user = user_fixture()
-
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(user, url)
-        end)
-
+      token = generate_confirmation_token(user)
       %{user: user, token: token}
     end
 

--- a/test/shroud_web/controllers/user_confirmation_controller_test.exs
+++ b/test/shroud_web/controllers/user_confirmation_controller_test.exs
@@ -67,10 +67,7 @@ defmodule ShroudWeb.UserConfirmationControllerTest do
 
   describe "POST /users/confirm/:token" do
     test "confirms the given token once", %{conn: conn, user: user} do
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(user, url)
-        end)
+      token = generate_confirmation_token(user)
 
       conn = post(conn, ~p"/users/confirm/#{token}")
       assert redirected_to(conn) == "/"

--- a/test/shroud_web/controllers/user_registration_controller_test.exs
+++ b/test/shroud_web/controllers/user_registration_controller_test.exs
@@ -49,7 +49,7 @@ defmodule ShroudWeb.UserRegistrationControllerTest do
 
       response = html_response(conn, 200)
       assert response =~ "Sign up"
-      assert response =~ "must have the @ sign and no spaces"
+      assert response =~ "is invalid"
       assert response =~ "should be at least 12 character"
     end
 

--- a/test/shroud_web/controllers/user_settings_controller_test.exs
+++ b/test/shroud_web/controllers/user_settings_controller_test.exs
@@ -101,7 +101,7 @@ defmodule ShroudWeb.UserSettingsControllerTest do
         })
 
       response = html_response(conn, 200)
-      assert response =~ "must have the @ sign and no spaces"
+      assert response =~ "is invalid"
       assert response =~ "is not valid"
     end
   end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -37,4 +37,18 @@ defmodule Shroud.AccountsFixtures do
     [_, token | _] = String.split(captured_email.text_body, "[TOKEN]")
     token
   end
+
+  @doc """
+  Builds and persists a confirmation token for `user`, returning the encoded
+  (URL-safe) token string that `confirm_user/1` accepts.
+
+  Mirrors the token-creation half of `Accounts.deliver_user_confirmation_instructions/2`
+  without enqueuing the email job — useful for tests that need a valid token to
+  feed to `confirm_user/1` without exercising delivery.
+  """
+  def generate_confirmation_token(%User{} = user) do
+    {encoded_token, user_token} = Shroud.Accounts.UserToken.build_email_token(user, "confirm")
+    Repo.insert!(user_token)
+    encoded_token
+  end
 end


### PR DESCRIPTION
We were getting some errors from users trying to sign up with invalid emails. Our app accepted them, but gen_smtp then errored out when trying to send a confirmation email. These emails are now validated correctly.