### PR TITLE
feat: add copy buttons to alias list

### DIFF
--- a/lib/shroud_web/components/copy_to_clipboard_button.ex
+++ b/lib/shroud_web/components/copy_to_clipboard_button.ex
@@ -1,15 +1,18 @@
 defmodule ShroudWeb.Components.CopyToClipboardButton do
   use ShroudWeb, :component
 
+  attr(:id, :string, default: nil)
   attr(:text, :string, required: true)
-  attr(:class, :string, required: false)
+  attr(:class, :string, default: nil)
 
   def copy_to_clipboard_button(assigns) do
     ~H"""
     <div x-data="{ tooltip: 'Copy to clipboard' }" class={@class}>
       <button
+        id={@id}
         x-tooltip="tooltip"
         type="button"
+        aria-label={"Copy #{@text} to clipboard"}
         class="rounded p-1 focus:ring focus:ring-indigo-500"
         data-clipboard-text={@text}
         x-on:click="

--- a/lib/shroud_web/live/email_alias_live/index.ex
+++ b/lib/shroud_web/live/email_alias_live/index.ex
@@ -11,6 +11,7 @@ defmodule ShroudWeb.EmailAliasLive.Index do
 
   import ShroudWeb.Components.{
     ButtonWithDropdown,
+    CopyToClipboardButton,
     DropdownItem
   }
 

--- a/lib/shroud_web/live/email_alias_live/index.html.heex
+++ b/lib/shroud_web/live/email_alias_live/index.html.heex
@@ -103,7 +103,7 @@
               <tr>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider sm:px-6"
                 >
                   Address
                 </th>
@@ -125,7 +125,7 @@
                 >
                   Created
                 </th>
-                <th scope="col" class="relative px-6 py-3">
+                <th scope="col" class="relative px-4 py-3 sm:px-6">
                   <span class="sr-only">Edit</span>
                 </th>
               </tr>
@@ -136,7 +136,7 @@
               class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"
             >
               <tr :for={{id, email_alias} <- @streams.aliases} id={id}>
-                <td class="px-6 py-4 whitespace-nowrap">
+                <td class="px-4 py-4 whitespace-nowrap sm:px-6">
                   <div>
                     <dl class="text-sm lg:hidden">
                       <dt class="sr-only">Status</dt>
@@ -152,12 +152,19 @@
                         <% end %>
                       </dd>
                     </dl>
-                    <.link
-                      navigate={~p"/alias/#{email_alias.address}"}
-                      class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-500 dark:hover:text-gray-400"
-                    >
-                      {email_alias.address}
-                    </.link>
+                    <div class="flex items-center">
+                      <.link
+                        navigate={~p"/alias/#{email_alias.address}"}
+                        class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-500 dark:hover:text-gray-400"
+                      >
+                        {email_alias.address}
+                      </.link>
+                      <.copy_to_clipboard_button
+                        id={"copy-alias-#{email_alias.id}"}
+                        class="ml-2"
+                        text={email_alias.address}
+                      />
+                    </div>
                     <div class="text-sm text-gray-500 dark:text-gray-400">
                       {email_alias.title}
                     </div>
@@ -191,7 +198,7 @@
                 <td class="hidden px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 sm:table-cell">
                   {Timex.format!(email_alias.inserted_at, "{ISOdate}")}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <td class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium sm:px-6">
                   <.link
                     navigate={~p"/alias/#{email_alias.address}"}
                     class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300"

--- a/test/shroud_web/components/copy_to_clipboard_button_test.exs
+++ b/test/shroud_web/components/copy_to_clipboard_button_test.exs
@@ -4,8 +4,8 @@ defmodule ShroudWeb.Components.CopyToClipboardButtonTest do
   import Phoenix.LiveViewTest
   import ShroudWeb.Components.CopyToClipboardButton
 
-  defp render_button(text) do
-    assigns = %{text: text, class: ""}
+  defp render_button(text, attrs \\ %{}) do
+    assigns = Map.merge(%{text: text}, attrs)
 
     render_component(&copy_to_clipboard_button/1, assigns)
   end
@@ -16,6 +16,13 @@ defmodule ShroudWeb.Components.CopyToClipboardButtonTest do
     assert html =~ ~s(data-clipboard-text="hello@example.com")
     # The click handler reads from the data attribute, never interpolates the value.
     assert html =~ "$el.dataset.clipboardText"
+  end
+
+  test "renders an accessible label and optional id" do
+    html = render_button("hello@example.com", %{id: "copy-alias-1"})
+
+    assert html =~ ~s(id="copy-alias-1")
+    assert html =~ ~s(aria-label="Copy hello@example.com to clipboard")
   end
 
   test "escapes script-injection content" do

--- a/test/shroud_web/live/email_alias_live_test.exs
+++ b/test/shroud_web/live/email_alias_live_test.exs
@@ -23,6 +23,15 @@ defmodule ShroudWeb.EmailAliasLiveTest do
       assert html =~ email_alias.address
     end
 
+    test "renders a copy button for each email alias", %{conn: conn, email_alias: email_alias} do
+      {:ok, index_live, _html} = live(conn, ~p"/")
+
+      assert has_element?(
+               index_live,
+               "#copy-alias-#{email_alias.id}[data-clipboard-text='#{email_alias.address}']"
+             )
+    end
+
     test "creates new email_alias", %{conn: conn} do
       {:ok, index_live, _html} =
         conn


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Shroud-email/shroud.email/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

